### PR TITLE
Support end-to-end snippets test

### DIFF
--- a/src/BluehawkSource.ts
+++ b/src/BluehawkSource.ts
@@ -1,0 +1,59 @@
+import MagicString from "magic-string";
+import path from "path";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type CommandAttributes = { [forCommandName: string]: any };
+
+// Represents a file
+export class BluehawkSource {
+  constructor({
+    text,
+    language,
+    path,
+    attributes,
+  }: {
+    text: string | MagicString;
+    language: string;
+    path: string;
+    attributes?: { [key: string]: string };
+  }) {
+    this.text =
+      typeof text === "string" || text instanceof String
+        ? new MagicString(text as string)
+        : text.clone();
+
+    this.path = path;
+    this.attributes = attributes ?? {};
+    this.language = language;
+  }
+
+  // Store the source text as a conveniently editable magic string.
+  // See https://www.npmjs.com/package/magic-string for details.
+  text: MagicString;
+  path: string;
+  language: string;
+  attributes: CommandAttributes;
+
+  // Returns the name of the file minus the file extension
+  get name(): string {
+    return path.basename(this.path, this.extension);
+  }
+
+  get basename(): string {
+    return path.basename(this.path);
+  }
+
+  get extension(): string {
+    return path.extname(this.path);
+  }
+
+  get dirname(): string {
+    return path.dirname(this.path);
+  }
+
+  // Returns the path with the given infix inserted between the file name and
+  // the file extension, e.g. some.infix + example.js -> example.some.infix.js
+  pathWithInfix = (infix: string): string => {
+    return `${this.dirname}/${this.name}.${infix}${this.extension}`;
+  };
+}

--- a/src/bluehawk.ts
+++ b/src/bluehawk.ts
@@ -5,7 +5,7 @@ import { CommandNode } from "./parser/CommandNode";
 import { validateVisitorResult } from "./parser/validator";
 import { RootParser } from "./parser/RootParser";
 import { COMMAND_PATTERN } from "./lexer/tokens";
-import MagicString from "magic-string";
+import { BluehawkSource } from "./BluehawkSource";
 
 export interface Location {
   line: number;
@@ -27,35 +27,6 @@ export class BluehawkResult {
   errors: BluehawkError[];
   commands: CommandNode[];
   source: BluehawkSource;
-}
-
-export class BluehawkSource {
-  constructor({
-    text,
-    language,
-    filePath,
-    attributes,
-  }: {
-    text: string | MagicString;
-    language: string;
-    filePath: string;
-    attributes?: { [key: string]: string };
-  }) {
-    this.text =
-      typeof text === "string" || text instanceof String
-        ? new MagicString(text as string)
-        : text.clone();
-    this.language = language;
-    this.filePath = filePath;
-    this.attributes = attributes ?? {};
-  }
-
-  // Store the source text as a conveniently editable magic string.
-  // See https://www.npmjs.com/package/magic-string for details.
-  text: MagicString;
-  language: string;
-  filePath: string;
-  attributes: { [key: string]: string };
 }
 
 export class Bluehawk {

--- a/src/parser/validator.ts
+++ b/src/parser/validator.ts
@@ -32,7 +32,7 @@ function validateCst(
   commandNode: CommandNode,
   result: ValidateCstResult
 ): void {
-  commandNode.children.forEach((child) => {
+  commandNode.children?.forEach((child) => {
     validateCst(child, result);
   });
   const rules: { [k: string]: Rule[] } = {

--- a/src/processors/StateCommand.ts
+++ b/src/processors/StateCommand.ts
@@ -8,12 +8,16 @@ export const StateCommand = (request: ProcessRequest): void => {
   const stateAttribute = source.attributes["state"];
   if (stateAttribute === undefined) {
     // We are not processing in a state file, so start one
-    processor.fork(`${source.filePath}.state.${command.id}`, bluehawkResult, {
-      ...source.attributes,
-      // Set the state attribute for next time StateCommand is invoked on the
-      // new file
-      state: command.id,
-    });
+    processor.fork(
+      source.pathWithInfix(`state.${command.id}`),
+      bluehawkResult,
+      {
+        ...source.attributes,
+        // Set the state attribute for next time StateCommand is invoked on the
+        // new file
+        state: command.id,
+      }
+    );
     return;
   }
 

--- a/src/processors/removeCommand.test.ts
+++ b/src/processors/removeCommand.test.ts
@@ -1,4 +1,5 @@
-import { Bluehawk, BluehawkSource } from "../bluehawk";
+import { Bluehawk } from "../bluehawk";
+import { BluehawkSource } from "../BluehawkSource";
 import { RemoveCommand } from "./RemoveCommand";
 import { Processor } from "./Processor";
 
@@ -23,7 +24,7 @@ console.log(bar);
     const source = new BluehawkSource({
       text: singleInput,
       language: "javascript",
-      filePath: "test.js",
+      path: "test.js",
     });
 
     const bluehawkResult = bluehawk.run(source);
@@ -47,7 +48,7 @@ d
 e
 `,
       language: "javascript",
-      filePath: "test.js",
+      path: "test.js",
     });
 
     const bluehawkResult = bluehawk.run(source);

--- a/src/processors/snippetCommand.test.ts
+++ b/src/processors/snippetCommand.test.ts
@@ -1,11 +1,14 @@
-import { Bluehawk, BluehawkSource } from "../bluehawk";
+import { Bluehawk } from "../bluehawk";
+import { BluehawkSource } from "../BluehawkSource";
 import { SnippetCommand } from "./SnippetCommand";
+import { RemoveCommand } from "./RemoveCommand";
 import { Processor } from "./Processor";
 
 describe("snippet Command", () => {
   const bluehawk = new Bluehawk();
   const processor = new Processor();
   processor.registerCommand("snippet", SnippetCommand);
+  processor.registerCommand("hide", RemoveCommand);
 
   it("performs extraction", () => {
     const snippet = `describe("some stuff", () => {
@@ -22,18 +25,18 @@ ${snippet}
 console.log(bar);
 `,
       language: "javascript",
-      filePath: "snippet.test.js",
+      path: "snippet.test.js",
     });
 
     const bluehawkResult = bluehawk.run(source);
     const files = processor.process(bluehawkResult);
     expect(Object.keys(files)).toStrictEqual([
       "snippet.test.js",
-      "snippet.test.js.codeblock.foo",
+      "./snippet.test.codeblock.foo.js",
     ]);
-    expect(files["snippet.test.js.codeblock.foo"].source.text.toString()).toBe(
-      `${snippet}\n`
-    );
+    expect(
+      files["./snippet.test.codeblock.foo.js"].source.text.toString()
+    ).toBe(`${snippet}\n`);
   });
 
   it("dedents the snippet", () => {
@@ -46,15 +49,53 @@ console.log(bar);
     // :snippet-end:
 `,
       language: "javascript",
-      filePath: "snippet.test.js",
+      path: "snippet.test.js",
     });
 
     const bluehawkResult = bluehawk.run(source);
     const files = processor.process(bluehawkResult);
-    expect(files["snippet.test.js.codeblock.foo"].source.text.toString()).toBe(
+    expect(
+      files["./snippet.test.codeblock.foo.js"].source.text.toString()
+    ).toBe(
       `  abc
    def
 ghi
+`
+    );
+  });
+
+  it("dedents a realistic snippet", () => {
+    const source = new BluehawkSource({
+      text: `        // :snippet-start: delete-collection
+        let realm = try! Realm()
+        try! realm.write {
+            // Find dogs younger than 2 years old.
+            let puppies = realm.objects(CrudExample_Dog.self).filter("age < 2")
+
+            // Delete the objects in the collection from the realm.
+            realm.delete(puppies);
+        }
+        // :snippet-end:
+`,
+      language: "swift",
+      path: "snippet.test.swift",
+    });
+
+    const bluehawkResult = bluehawk.run(source);
+    const files = processor.process(bluehawkResult);
+    expect(
+      files[
+        "./snippet.test.codeblock.delete-collection.swift"
+      ].source.text.toString()
+    ).toBe(
+      `let realm = try! Realm()
+try! realm.write {
+    // Find dogs younger than 2 years old.
+    let puppies = realm.objects(CrudExample_Dog.self).filter("age < 2")
+
+    // Delete the objects in the collection from the realm.
+    realm.delete(puppies);
+}
 `
     );
   });
@@ -66,13 +107,33 @@ ghi
     // :snippet-end:
 `,
       language: "javascript",
-      filePath: "snippet.test.js",
+      path: "snippet.test.js",
     });
 
     const bluehawkResult = bluehawk.run(source);
     const files = processor.process(bluehawkResult);
-    expect(files["snippet.test.js.codeblock.foo"].source.text.toString()).toBe(
-      ""
-    );
+    expect(
+      files["./snippet.test.codeblock.foo.js"].source.text.toString()
+    ).toBe("");
+  });
+
+  it("handles adjusted offsets", () => {
+    const source = new BluehawkSource({
+      text: `some text
+// :snippet-start: foo
+// :hide-start:
+hide this
+// :hide-end:
+// :snippet-end:
+`,
+      language: "javascript",
+      path: "snippet.test.js",
+    });
+
+    const bluehawkResult = bluehawk.run(source);
+    const files = processor.process(bluehawkResult);
+    expect(
+      files["./snippet.test.codeblock.foo.js"].source.text.toString()
+    ).toBe("");
   });
 });

--- a/src/processors/stateCommand.test.ts
+++ b/src/processors/stateCommand.test.ts
@@ -1,5 +1,5 @@
-import { join } from "path";
-import { Bluehawk, BluehawkSource } from "../bluehawk";
+import { Bluehawk } from "../bluehawk";
+import { BluehawkSource } from "../BluehawkSource";
 import { Processor } from "./Processor";
 import { StateCommand } from "./StateCommand";
 import { RemoveCommand } from "./RemoveCommand";
@@ -20,7 +20,7 @@ describe("stateCommand", () => {
 end
 `,
     language: "javascript",
-    filePath: join(__dirname, "stateCommand.test.ts"),
+    path: "stateCommand.test.ts",
   });
   const singleBegin = `
 let foo = undefined;
@@ -49,7 +49,7 @@ someTest()
 end
 `,
     language: "javascript",
-    filePath: "stateCommand.test.js",
+    path: "stateCommand.test.js",
   });
   const nestedBegin = `
 let foo = undefined;
@@ -90,7 +90,7 @@ console.log("we are foo");
 end
 `,
       language: "javascript",
-      filePath: "stateCommand.test.js",
+      path: "stateCommand.test.js",
     });
     const multipleBegin = `
 let foo = undefined;
@@ -105,22 +105,22 @@ console.log("we are foo");
 end
 `;
     const bluehawkResult = bluehawk.run(multipleInput);
-    expect(bluehawkResult.source.filePath).toBe("stateCommand.test.js");
+    expect(bluehawkResult.source.path).toBe("stateCommand.test.js");
     const files = processor.process(bluehawkResult);
     // wait what? Two snippets?
     // It's because the snippet lives outside of the states
     // There would only be one snippet publish if it was nested
     expect(Object.keys(files)).toStrictEqual([
       "stateCommand.test.js",
-      "stateCommand.test.js.state.begin",
-      "stateCommand.test.js.state.begin.codeblock.foo",
-      "stateCommand.test.js.codeblock.foo",
-      "stateCommand.test.js.state.final",
-      "stateCommand.test.js.state.final.codeblock.foo",
+      "./stateCommand.test.state.begin.js",
+      "./stateCommand.test.state.begin.codeblock.foo.js",
+      "./stateCommand.test.codeblock.foo.js",
+      "./stateCommand.test.state.final.js",
+      "./stateCommand.test.state.final.codeblock.foo.js",
     ]);
 
     expect(
-      files["stateCommand.test.js.state.final"].source.text.toString()
+      files["./stateCommand.test.state.final.js"].source.text.toString()
     ).toBe(multipleFinal);
   });
 });

--- a/src/processors/uncommentCommand.test.ts
+++ b/src/processors/uncommentCommand.test.ts
@@ -1,4 +1,5 @@
-import { Bluehawk, BluehawkSource } from "../bluehawk";
+import { Bluehawk } from "../bluehawk";
+import { BluehawkSource } from "../BluehawkSource";
 import { UncommentCommand } from "./UncommentCommand";
 import { RemoveCommand } from "./RemoveCommand";
 import { Processor } from "./Processor";
@@ -18,7 +19,7 @@ no comment
 // :uncomment-end:
 `,
       language: "javascript",
-      filePath: "uncomment.test.js",
+      path: "uncomment.test.js",
     });
 
     const bluehawkResult = bluehawk.run(source);
@@ -40,7 +41,7 @@ no comment
 // :uncomment-end:
 `,
       language: "javascript",
-      filePath: "uncomment.test.js",
+      path: "uncomment.test.js",
     });
 
     const bluehawkResult = bluehawk.run(source);
@@ -64,7 +65,7 @@ no comment
 // :uncomment-end:
 `,
       language: "javascript",
-      filePath: "uncomment.test.js",
+      path: "uncomment.test.js",
     });
 
     const bluehawkResult = bluehawk.run(source);
@@ -89,7 +90,7 @@ no comment
 // :uncomment-end:
 `,
       language: "javascript",
-      filePath: "uncomment.test.js",
+      path: "uncomment.test.js",
     });
 
     const bluehawkResult = bluehawk.run(source);

--- a/src/test/bluehawk.test.ts
+++ b/src/test/bluehawk.test.ts
@@ -1,4 +1,5 @@
-import { Bluehawk, BluehawkSource } from "../bluehawk";
+import { Bluehawk } from "../bluehawk";
+import { BluehawkSource } from "../BluehawkSource";
 
 describe("bluehawk", () => {
   const bluehawk = new Bluehawk();
@@ -12,7 +13,7 @@ describe("bluehawk", () => {
     :some-command-end:
 `,
       language: "testlanguage",
-      filePath: "testPath",
+      path: "testPath",
     });
     const output = bluehawk.run(input);
     expect(output.errors).toStrictEqual([]);
@@ -26,7 +27,7 @@ describe("bluehawk", () => {
     :some-command-end:
     `,
       language: "testlanguage",
-      filePath: "testPath",
+      path: "testPath",
     });
     const output = bluehawk.run(input);
     expect(output.errors.length).toBe(1);
@@ -50,7 +51,7 @@ describe("bluehawk", () => {
     :some-command-start:
 `,
       language: "testlanguage",
-      filePath: "testPath",
+      path: "testPath",
     });
     const output = bluehawk.run(input);
     expect(output.errors.length).toBe(1);
@@ -75,7 +76,7 @@ describe("bluehawk", () => {
     :some-command-end:
 `,
       language: "testlanguage",
-      filePath: "testPath",
+      path: "testPath",
     });
     const output = bluehawk.run(input);
     expect(output.errors.length).toBe(0);
@@ -91,7 +92,7 @@ describe("bluehawk", () => {
     :code-block-end:
 `,
       language: "testlanguage",
-      filePath: "testPath",
+      path: "testPath",
     });
     const output = bluehawk.run(input);
     expect(output.errors.length).toBe(1);

--- a/src/test/jsonAttributeList.test.ts
+++ b/src/test/jsonAttributeList.test.ts
@@ -2,7 +2,7 @@ import { RootParser } from "../parser/RootParser";
 import { makeCstVisitor } from "../parser/makeCstVisitor";
 import { makeBlockCommentTokens } from "../lexer/makeBlockCommentTokens";
 import { makeLineCommentToken } from "../lexer/makeLineCommentToken";
-import { BluehawkSource } from "../bluehawk";
+import { BluehawkSource } from "../BluehawkSource";
 
 describe("JSON attribute lists", () => {
   const parser = new RootParser([
@@ -13,7 +13,7 @@ describe("JSON attribute lists", () => {
   const source = new BluehawkSource({
     language: "mock",
     text: "mock",
-    filePath: "mock",
+    path: "mock",
   });
 
   it("accepts empty attribute lists", () => {

--- a/src/test/multilang.test.ts
+++ b/src/test/multilang.test.ts
@@ -1,4 +1,4 @@
-import { BluehawkSource } from "../bluehawk";
+import { BluehawkSource } from "../BluehawkSource";
 import { makeBlockCommentTokens } from "../lexer/makeBlockCommentTokens";
 import { makeLineCommentToken } from "../lexer/makeLineCommentToken";
 import { makePushParserTokens } from "../lexer/makePushParserTokens";
@@ -41,7 +41,7 @@ CC
 describe("multilang", () => {
   const someSource = new BluehawkSource({
     language: "mock",
-    filePath: "mock",
+    path: "mock",
     text: "mock",
   });
   const parser = new RootParser([

--- a/src/test/validator.test.ts
+++ b/src/test/validator.test.ts
@@ -3,11 +3,11 @@ import { makeCstVisitor } from "../parser/makeCstVisitor";
 import { validateVisitorResult } from "../parser/validator";
 import { makeBlockCommentTokens } from "../lexer/makeBlockCommentTokens";
 import { makeLineCommentToken } from "../lexer/makeLineCommentToken";
-import { BluehawkSource } from "../bluehawk";
+import { BluehawkSource } from "../BluehawkSource";
 
 describe("validator", () => {
   const source = new BluehawkSource({
-    filePath: "",
+    path: "",
     language: "",
     text: "",
   });
@@ -270,5 +270,18 @@ the quick brown fox jumped
         offset: 96,
       },
     });
+  });
+
+  it("handles line commands", () => {
+    const tokens = lexer.tokenize(`// :unknown-line-command:
+`);
+    expect(tokens.errors.length).toBe(0);
+    parser.input = tokens.tokens;
+    const cst = parser.annotatedText();
+    expect(parser.errors).toStrictEqual([]);
+    const visitor = makeCstVisitor(parser);
+    const result = visitor.visit(cst, source);
+    const validateResult = validateVisitorResult(result);
+    expect(validateResult.commandsById.size).toBe(0);
   });
 });

--- a/src/test/visitor.test.ts
+++ b/src/test/visitor.test.ts
@@ -2,7 +2,7 @@ import { RootParser } from "../parser/RootParser";
 import { makeCstVisitor } from "../parser/makeCstVisitor";
 import { makeBlockCommentTokens } from "../lexer/makeBlockCommentTokens";
 import { makeLineCommentToken } from "../lexer/makeLineCommentToken";
-import { BluehawkSource } from "../bluehawk";
+import { BluehawkSource } from "../BluehawkSource";
 
 describe("visitor", () => {
   const parser = new RootParser([
@@ -13,7 +13,7 @@ describe("visitor", () => {
   const source = new BluehawkSource({
     language: "mock",
     text: "mock",
-    filePath: "mock",
+    path: "mock",
   });
 
   it("can be constructed", () => {
@@ -89,6 +89,7 @@ annotated text
     expect(result.errors[0].message).toBe(
       "Unexpected this-is-a-different-command-end closing this-is-a-command-start"
     );
+    expect(result.commands.length).toBe(0);
   });
 
   it("supports nested commands", () => {


### PR DESCRIPTION
- Add "--snippets" flag to cli to output snippets at destination
- Refactor BluehawkSource
- Fix slice -> snip
- Fix line command validator
- Support dedent on realistic codeblocks (not fully indented on blank lines)
- Protect against mismatch start/end tags
- Report errors on cli