### PR TITLE
Support state output

### DIFF
--- a/src/BluehawkSource.ts
+++ b/src/BluehawkSource.ts
@@ -1,5 +1,5 @@
 import MagicString from "magic-string";
-import path from "path";
+import path, { join } from "path";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type CommandAttributes = { [forCommandName: string]: any };
@@ -11,28 +11,61 @@ export class BluehawkSource {
     language,
     path,
     attributes,
+    modifier,
   }: {
     text: string | MagicString;
     language: string;
     path: string;
     attributes?: { [key: string]: string };
+    modifier?: string;
   }) {
     this.text =
       typeof text === "string" || text instanceof String
         ? new MagicString(text as string)
         : text.clone();
 
-    this.path = path;
+    this.path = join(path);
     this.attributes = attributes ?? {};
     this.language = language;
+    this.modifier = modifier;
   }
 
   // Store the source text as a conveniently editable magic string.
   // See https://www.npmjs.com/package/magic-string for details.
   text: MagicString;
   path: string;
+  // A file at one path may result in multiple output files after processing
+  // (e.g. states). Different instances of the same file can be distinguished
+  // with a modifier.
+  modifier?: string;
   language: string;
   attributes: CommandAttributes;
+
+  // Returns a modifier combined with a hypothetical new modifier. This allows
+  // you to uniformly create modifiers, even from files with existing modifiers.
+  static makeModifier = (
+    originalModifier?: string,
+    newModifier?: string
+  ): string | undefined => {
+    const elements: string[] = [];
+    if (originalModifier !== undefined) {
+      elements.push(originalModifier);
+    }
+    if (newModifier !== undefined) {
+      elements.push(newModifier);
+    }
+    return elements.length > 0 ? elements.join("#") : undefined;
+  };
+
+  // Returns a uniform path + modifier combination to uniquely identify a file
+  // instance.
+  static makeId = (newPath: string, modifier?: string): string => {
+    const elements = [newPath];
+    if (modifier !== undefined) {
+      elements.push(modifier);
+    }
+    return elements.join("#");
+  };
 
   // Returns the name of the file minus the file extension
   get name(): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ import * as fileHandler from "./fileHandler";
 import * as bhp from "./fs/parseSource";
 import fs from "fs";
 import path from "path";
+import { Bluehawk, BluehawkResult } from "./bluehawk";
+import { Listener } from "./processors/Processor";
 
 const output = MessageHandler.getMessageHandler();
 
@@ -13,8 +15,9 @@ async function run(): Promise<void> {
     .command("--source", "The file or folder to process")
     .command("--destination", "The output folder")
     .command("--ignores", "A glob list of patterns to ignore")
+    .command("--state", "Which state to render")
     .boolean("snippets")
-    .describe("snippets", "Output snippet files at destination")
+    .describe("snippets", "Output snippet files only")
     .example(
       "$0 -s ./foo.js -d ./output/",
       "Parse the foo.js file and output results in the output/ directory."
@@ -41,28 +44,115 @@ async function run(): Promise<void> {
     );
   }
 
+  const { snippets } = params;
+
+  const listeners: Listener[] = [];
+
+  // If a file contains the state command, the processor will generate multiple
+  // versions of the same file. Keep track of whether a state file was written
+  // for the desired state name. We can also use this to diagnose possible typos
+  // in params.state.
+  const stateVersionWrittenForPath: {
+    [path: string]: boolean;
+  } = {};
+
+  // Output snippet files -- exclude full state files
+  if (snippets) {
+    listeners.push((result: BluehawkResult) => {
+      const { source } = result;
+      if (source.attributes["snippet"] === undefined) {
+        return;
+      }
+      const targetPath = path.join(destination, source.basename);
+
+      // Special handler for snippets in state commands
+      if (params.state) {
+        const stateAttribute = source.attributes["state"];
+        if (stateAttribute && stateAttribute !== params.state) {
+          // Not the requested state
+          return;
+        }
+        const stateVersionWritten = stateVersionWrittenForPath[source.path];
+        if (stateVersionWritten === true) {
+          // Already wrote state version, so nothing more to do. This prevents a
+          // non-state version from overwriting the desired state version.
+          return;
+        }
+        if (stateAttribute === params.state) {
+          stateVersionWrittenForPath[source.path] = true;
+        }
+      }
+
+      fs.writeFile(targetPath, source.text.toString(), "utf8", (error) => {
+        if (error) {
+          throw error;
+        }
+        console.log(`${source.path} -> ${targetPath}`);
+      });
+    });
+  } else if (params.state) {
+    listeners.push((result: BluehawkResult) => {
+      const { source } = result;
+      if (source.attributes.snippet) {
+        // Not a pure state file
+        return;
+      }
+
+      const { state } = source.attributes;
+
+      if (state && state !== params.state) {
+        // This is a state file, but not the state we're looking for
+        return;
+      }
+
+      const stateVersionWritten = stateVersionWrittenForPath[source.path];
+      // Already wrote state version, so nothing more to do
+      if (stateVersionWritten === true) {
+        return;
+      }
+
+      // We will either write the state-processed version or the default
+      // version. If a file we already saved is later found to have had state
+      // commands in it, then the state version will overwrite it. However, we
+      // will never overwrite a state command processed version with the default
+      // version.
+      if (state === params.state) {
+        stateVersionWrittenForPath[source.path] = true;
+      }
+
+      const sourceParam = params.source as string;
+      const projectRoot = !fs.lstatSync(sourceParam as string).isDirectory()
+        ? path.dirname(sourceParam)
+        : sourceParam;
+
+      // Use the same relative path
+      const directory = path.join(
+        destination,
+        path.relative(projectRoot, path.dirname(source.path))
+      );
+      const targetPath = path.join(directory, source.basename);
+      fs.mkdir(directory, { recursive: true }, (error) => {
+        if (error) {
+          throw error;
+        }
+        fs.writeFile(targetPath, source.text.toString(), "utf8", (error) => {
+          if (error) {
+            throw error;
+          }
+          console.log(`${source.path} -> ${targetPath}`);
+        });
+      });
+    });
+  }
+
   const source = params.source as string;
   const destination = params.destination as string;
-  const results = await bhp.main(source, ignores);
+  await bhp.main(source, ignores, listeners);
 
-  const { snippets } = params;
-  if (snippets) {
-    results
-      .filter((result) => result.source.attributes["snippet"] !== undefined)
-      .forEach((result) => {
-        const targetPath = path.join(destination, result.source.basename);
-        fs.writeFile(
-          targetPath,
-          result.source.text.toString(),
-          "utf8",
-          (error) => {
-            if (error) {
-              throw error;
-            }
-            console.log(`${result.source.path} -> ${targetPath}`);
-          }
-        );
-      });
+  if (params.state && Object.keys(stateVersionWrittenForPath).length === 0) {
+    console.warn(
+      `Warning: state '${params.state}' never found in source ${source}`
+    );
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import * as fileHandler from "./fileHandler";
 import * as bhp from "./fs/parseSource";
 import fs from "fs";
 import path from "path";
-import { Bluehawk, BluehawkResult } from "./bluehawk";
+import { BluehawkResult } from "./bluehawk";
 import { Listener } from "./processors/Processor";
 
 const output = MessageHandler.getMessageHandler();

--- a/src/processors/SnippetCommand.ts
+++ b/src/processors/SnippetCommand.ts
@@ -1,8 +1,6 @@
-import { IToken } from "chevrotain";
 import MagicString from "magic-string";
 import { BluehawkSource } from "../BluehawkSource";
 import { CommandNode } from "../parser/CommandNode";
-import { flatten } from "../parser/flatten";
 import { ProcessRequest } from "./Processor";
 import { removeMetaRange } from "./removeMetaRange";
 
@@ -68,18 +66,18 @@ export const SnippetCommand = (request: ProcessRequest): void => {
   dedentRange(clonedSnippet, command);
 
   // Fork subset code block to another file
-  processor.fork(
-    source.pathWithInfix(`codeblock.${command.id}`),
-    {
+  processor.fork({
+    bluehawkResult: {
       commands: command.children ?? [],
       errors: [],
       source: new BluehawkSource({
         ...source,
+        path: source.pathWithInfix(`codeblock.${command.id}`),
         text: clonedSnippet,
       }),
     },
-    {
+    newAttributes: {
       snippet: command.id,
-    }
-  );
+    },
+  });
 };

--- a/src/processors/StateCommand.ts
+++ b/src/processors/StateCommand.ts
@@ -5,26 +5,25 @@ export const StateCommand = (request: ProcessRequest): void => {
   const { command, processor, bluehawkResult } = request;
   const { source } = bluehawkResult;
 
-  const stateAttribute = source.attributes["state"];
-  if (stateAttribute === undefined) {
-    // We are not processing in a state file, so start one
-    processor.fork(
-      source.pathWithInfix(`state.${command.id}`),
-      bluehawkResult,
-      {
-        ...source.attributes,
-        // Set the state attribute for next time StateCommand is invoked on the
-        // new file
-        state: command.id,
-      }
-    );
-    return;
-  }
-
   // Strip tags
   removeMetaRange(source.text, command);
 
-  // We are processing a state. Strip all other states.
+  const stateAttribute = source.attributes["state"];
+
+  if (stateAttribute === undefined) {
+    // We are not processing in a state file, so start one
+    processor.fork({
+      bluehawkResult,
+      newModifier: `state.${command.id}`,
+      newAttributes: {
+        // Set the state attribute for next time StateCommand is invoked on the
+        // new file
+        state: command.id,
+      },
+    });
+  }
+
+  // Strip all other states
   if (stateAttribute !== command.id) {
     const { contentRange } = command;
     source.text.remove(contentRange.start.offset, contentRange.end.offset);

--- a/src/processors/removeCommand.test.ts
+++ b/src/processors/removeCommand.test.ts
@@ -2,11 +2,39 @@ import { Bluehawk } from "../bluehawk";
 import { BluehawkSource } from "../BluehawkSource";
 import { RemoveCommand } from "./RemoveCommand";
 import { Processor } from "./Processor";
+import MagicString from "magic-string";
 
 describe("remove command", () => {
   const bluehawk = new Bluehawk();
   const processor = new Processor();
   processor.registerCommand("remove", RemoveCommand);
+  test("magic string allows double delete", () => {
+    // Check assumptions about magic string. At time of writing, magic string
+    // docs claim that "removing the same content twice, or making removals that
+    // partially overlap, will cause an error." In practice, this doesn't seem
+    // to be the case. In the interest of keeping processor code simple,
+    // Bluehawk relies on being able to delete the same thing multiple times.
+    const s = new MagicString(`line 1
+line 2
+line 3`);
+    expect(s.length()).toBe(s.original.length);
+    const lines = s.original.split("\n");
+    s.remove(0, lines[0].length + 1);
+    expect(s.length()).toBe(s.original.length - lines[0].length - 1);
+    s.remove(0, lines[0].length + 1); // Delete again -- no error
+    expect(s.length()).toBe(s.original.length - lines[0].length - 1);
+    expect(s.toString()).toBe(`line 2
+line 3`);
+    s.remove(3, 6); // Delete inner field again -- no error
+    expect(s.length()).toBe(s.original.length - lines[0].length - 1);
+    expect(s.toString()).toBe(`line 2
+line 3`);
+    s.remove(0, lines[0].length + lines[1].length + 2); // Delete overlapping field
+    expect(s.length()).toBe(
+      s.original.length - lines[0].length - lines[1].length - 2
+    );
+    expect(s.toString()).toBe(`line 3`);
+  });
 
   it("strips text", () => {
     const singleInput = `const bar = "foo"

--- a/src/processors/snippetCommand.test.ts
+++ b/src/processors/snippetCommand.test.ts
@@ -32,11 +32,11 @@ console.log(bar);
     const files = processor.process(bluehawkResult);
     expect(Object.keys(files)).toStrictEqual([
       "snippet.test.js",
-      "./snippet.test.codeblock.foo.js",
+      "snippet.test.codeblock.foo.js",
     ]);
-    expect(
-      files["./snippet.test.codeblock.foo.js"].source.text.toString()
-    ).toBe(`${snippet}\n`);
+    expect(files["snippet.test.codeblock.foo.js"].source.text.toString()).toBe(
+      `${snippet}\n`
+    );
   });
 
   it("dedents the snippet", () => {
@@ -54,9 +54,7 @@ console.log(bar);
 
     const bluehawkResult = bluehawk.run(source);
     const files = processor.process(bluehawkResult);
-    expect(
-      files["./snippet.test.codeblock.foo.js"].source.text.toString()
-    ).toBe(
+    expect(files["snippet.test.codeblock.foo.js"].source.text.toString()).toBe(
       `  abc
    def
 ghi
@@ -85,7 +83,7 @@ ghi
     const files = processor.process(bluehawkResult);
     expect(
       files[
-        "./snippet.test.codeblock.delete-collection.swift"
+        "snippet.test.codeblock.delete-collection.swift"
       ].source.text.toString()
     ).toBe(
       `let realm = try! Realm()
@@ -112,9 +110,9 @@ try! realm.write {
 
     const bluehawkResult = bluehawk.run(source);
     const files = processor.process(bluehawkResult);
-    expect(
-      files["./snippet.test.codeblock.foo.js"].source.text.toString()
-    ).toBe("");
+    expect(files["snippet.test.codeblock.foo.js"].source.text.toString()).toBe(
+      ""
+    );
   });
 
   it("handles adjusted offsets", () => {
@@ -132,8 +130,8 @@ hide this
 
     const bluehawkResult = bluehawk.run(source);
     const files = processor.process(bluehawkResult);
-    expect(
-      files["./snippet.test.codeblock.foo.js"].source.text.toString()
-    ).toBe("");
+    expect(files["snippet.test.codeblock.foo.js"].source.text.toString()).toBe(
+      ""
+    );
   });
 });

--- a/src/processors/stateCommand.test.ts
+++ b/src/processors/stateCommand.test.ts
@@ -112,15 +112,15 @@ end
     // There would only be one snippet publish if it was nested
     expect(Object.keys(files)).toStrictEqual([
       "stateCommand.test.js",
-      "./stateCommand.test.state.begin.js",
-      "./stateCommand.test.state.begin.codeblock.foo.js",
-      "./stateCommand.test.codeblock.foo.js",
-      "./stateCommand.test.state.final.js",
-      "./stateCommand.test.state.final.codeblock.foo.js",
+      "stateCommand.test.js#state.begin",
+      "stateCommand.test.codeblock.foo.js#state.begin",
+      "stateCommand.test.codeblock.foo.js",
+      "stateCommand.test.js#state.final",
+      "stateCommand.test.codeblock.foo.js#state.final",
     ]);
 
     expect(
-      files["./stateCommand.test.state.final.js"].source.text.toString()
+      files["stateCommand.test.js#state.final"].source.text.toString()
     ).toBe(multipleFinal);
   });
 });


### PR DESCRIPTION
Below are some examples of changes when running on realm tutorial codebase. Note that the changes are basically whitespace and newlines at end of file:

Generate tutorial snippets:
```shell
$ bluehawk -s swift-ios/ -d ~/docs/docs-realm/source/tutorial/generated/code/final  --state final --snippets
$ git diff
```
![image](https://user-images.githubusercontent.com/20050130/104524928-2a397f80-55cd-11eb-89c0-0e6f4474f515.png)

Generate tutorial repo branch:
```shell
$ bluehawk -s swift-ios/ -d ~/tutorial/realm-tutorial-ios-swift --state start
$ git diff
```
![image](https://user-images.githubusercontent.com/20050130/104525075-6ec51b00-55cd-11eb-975a-21517f5ef2a7.png)

