### PR TITLE
Handle binary file copy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1884,6 +1884,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "binaryextensions": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-4.15.0.tgz",
+      "integrity": "sha512-MkUl3szxXolQ2scI1PM14WOT951KnaTNJ0eMKg7WzOI4kvSxyNo/Cygx4LOBNhwyINhAuSQpJW1rYD9aBSxGaw=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2378,6 +2383,15 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "editions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-6.1.0.tgz",
+      "integrity": "sha512-h6nWEyIocfgho9J3sTSuhU/WoFOu1hTX75rPBebNrbF38Y9QFDjCDizYXdikHTySW7Y3mSxli8bpDz9RAtc7rA==",
+      "requires": {
+        "errlop": "^4.0.0",
+        "version-range": "^1.0.0"
+      }
+    },
     "emittery": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.7.2.tgz",
@@ -2397,6 +2411,11 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "errlop": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/errlop/-/errlop-4.1.0.tgz",
+      "integrity": "sha512-vul6gGBuVt0M2TPi1/WrcL86+Hb3Q2Tpu3TME3sbVhZrYf7J1ZMHCodI25RQKCVurh56qTfvgM0p3w5cT4reSQ=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -3718,6 +3737,16 @@
       "requires": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
+      }
+    },
+    "istextorbinary": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-5.12.0.tgz",
+      "integrity": "sha512-wLDRWD7qpNTYubk04+q3en1+XZGS4vYWK0+SxNSXJLaITMMEK+J3o/TlOMyULeH1qozVZ9uUkKcyMA8odyxz8w==",
+      "requires": {
+        "binaryextensions": "^4.15.0",
+        "editions": "^6.1.0",
+        "textextensions": "^5.11.0"
       }
     },
     "jest": {
@@ -6799,6 +6828,11 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "textextensions": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-5.12.0.tgz",
+      "integrity": "sha512-IYogUDaP65IXboCiPPC0jTLLBzYlhhw2Y4b0a2trPgbHNGGGEfuHE6tds+yDcCf4mpNDaGISFzwSSezcXt+d6w=="
+    },
     "throat": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
@@ -7123,6 +7157,19 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "version-compare": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/version-compare/-/version-compare-1.1.0.tgz",
+      "integrity": "sha512-zVKtPOJTC9x23lzS4+4D7J+drq80BXVYAmObnr5zqxxFVH7OffJ1lJlAS7LYsQNV56jx/wtbw0UV7XHLrvd6kQ=="
+    },
+    "version-range": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/version-range/-/version-range-1.1.0.tgz",
+      "integrity": "sha512-R1Ggfg2EXamrnrV3TkZ6yBNgITDbclB3viwSjbZ3+eK0VVNK4ajkYJTnDz5N0bIMYDtK9MUBvXJUnKO5RWWJ6w==",
+      "requires": {
+        "version-compare": "^1.0.0"
       }
     },
     "vscode-jsonrpc": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ignore": "^5.1.8",
     "ignore-walk": "^3.0.3",
     "inquirer": "^7.3.3",
+    "istextorbinary": "^5.12.0",
     "line-reader": "^0.4.0",
     "magic-string": "^0.25.7",
     "rimraf": "^3.0.2",


### PR DESCRIPTION
Original implementation would heedlessly open binary files and save them as text files. This fixes that by providing a special handler for binary files, which in this case just copies them directly.
