### PR TITLE
Fix coverage to use ts output

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: "ts-jest",
+  testRegex: "\\.test\\.ts$",
   testEnvironment: "node",
   collectCoverage: true,
   coverageReporters: ["text", "html"],


### PR DESCRIPTION
- Something changed where the uncovered line reporting was reporting js instead of ts lines
- This restores it so that ts lines are used in coverage