### PR TITLE
Schema conform, TypeScript strict mode, and Replace command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1188,6 +1188,24 @@
         "resolve": "~1.12.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        },
         "resolve": {
           "version": "1.12.3",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.3.tgz",
@@ -1598,14 +1616,13 @@
       }
     },
     "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
+      "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
       }
     },
@@ -2498,6 +2515,18 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -2564,6 +2593,12 @@
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         },
         "regexpp": {
@@ -2962,8 +2997,7 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fast-diff": {
       "version": "1.2.0",
@@ -3273,6 +3307,26 @@
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        }
       }
     },
     "has": {
@@ -5186,10 +5240,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -5837,8 +5890,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -6012,6 +6064,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
     "require-main-filename": {
       "version": "2.0.0",
@@ -6770,6 +6827,18 @@
         "string-width": "^3.0.0"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -6786,6 +6855,12 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
           "dev": true
         },
         "string-width": {
@@ -7095,10 +7170,9 @@
       }
     },
     "uri-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
-      "dev": true,
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "ajv": "^7.0.3",
     "chevrotain": "^7.0.2",
     "fs": "0.0.1-security",
     "fsify": "^4.0.1",

--- a/src/bluehawk.ts
+++ b/src/bluehawk.ts
@@ -6,7 +6,7 @@ import { RootParser } from "./parser/RootParser";
 import { COMMAND_PATTERN } from "./parser/lexer/tokens";
 import { Document } from "./Document";
 import { Listener, Processor, BluehawkFiles } from "./processor/Processor";
-import { Command } from "./commands/Command";
+import { AnyCommand } from "./commands/Command";
 import { ParseResult } from "./parser/ParseResult";
 import { strict as assert } from "assert";
 
@@ -14,7 +14,7 @@ import { strict as assert } from "assert";
 export class Bluehawk {
   // Register the given command on the processor and validator. This enables
   // support for the command under the given name.
-  registerCommand(name: string, command: Command): void {
+  registerCommand(name: string, command: AnyCommand): void {
     this.processor.registerCommand(name, command);
   }
 

--- a/src/bluehawk.ts
+++ b/src/bluehawk.ts
@@ -8,6 +8,7 @@ import { Document } from "./Document";
 import { Listener, Processor, BluehawkFiles } from "./processor/Processor";
 import { Command } from "./commands/Command";
 import { ParseResult } from "./parser/ParseResult";
+import { strict as assert } from "assert";
 
 // The frontend of Bluehawk
 export class Bluehawk {
@@ -35,8 +36,17 @@ export class Bluehawk {
       ]);
       this.parsers.set(source.language, [parser, makeCstVisitor(parser)]);
     }
-    const [parser, visitor] = this.parsers.get(source.language);
+    const parserVisitorTuple = this.parsers.get(source.language);
+    assert(parserVisitorTuple !== undefined);
+    const [parser, visitor] = parserVisitorTuple;
     const parseResult = parser.parse(source.text.original);
+    if (parseResult.cst === undefined) {
+      return {
+        commandNodes: [],
+        errors: parseResult.errors,
+        source,
+      };
+    }
     const visitorResult = visitor.visit(parseResult.cst, source);
     const validateErrors = validateCommands(
       visitorResult.commandNodes,

--- a/src/commands/Command.ts
+++ b/src/commands/Command.ts
@@ -1,13 +1,24 @@
 import { Rule } from "../processor/validator";
 import { ProcessRequest } from "../processor/Processor";
+import { AnySchema, JSONSchemaType } from "ajv";
 
 // The implementation that actually carries out the command.
 
-export interface Command {
-  // Rules to determine if the command meets requirements before processing is
-  // possible
+export interface AnyCommand {
+  // A helpful description of what the command is supposed to do
+  description?: string;
+
+  // JSON schema of the attributes list
+  attributesSchema?: AnySchema;
+
+  // Validator rules to determine if the command meets requirements before
+  // processing is possible
   rules: Rule[];
 
   // Implementation of the command
   process: (request: ProcessRequest) => void | Promise<void>;
+}
+
+export interface Command<AttributesType = unknown> extends AnyCommand {
+  attributesSchema?: JSONSchemaType<AttributesType>;
 }

--- a/src/commands/ReplaceCommand.ts
+++ b/src/commands/ReplaceCommand.ts
@@ -1,0 +1,64 @@
+import { makeAttributesConformToJsonSchemaRule } from "../processor/makeAttributesConformToJsonSchemaRule";
+import { ProcessRequest } from "../processor/Processor";
+import { Command } from "./Command";
+import { removeMetaRange } from "./removeMetaRange";
+
+type ReplaceCommandAttributes = {
+  // Replace '<key>' with '<value>'
+  [searchTerm: string]: /* replaceTerm */ string;
+};
+
+export const ReplaceCommand: Command = {
+  rules: [
+    makeAttributesConformToJsonSchemaRule<ReplaceCommandAttributes>({
+      type: "object",
+      additionalProperties: { type: "string" },
+      minProperties: 1,
+    }),
+  ],
+
+  process: ({ command, parseResult }: ProcessRequest): void => {
+    const { attributes } = command;
+    if (attributes === undefined) {
+      // TODO: error (though this can't happen if the validator was used
+      return;
+    }
+
+    const { source } = parseResult;
+    const { text } = source;
+
+    // Strip tags
+    removeMetaRange(text, command);
+
+    const { contentRange } = command;
+    if (contentRange == undefined) {
+      // TODO: error
+      return;
+    }
+    const contentLength = contentRange.end.offset - contentRange.start.offset;
+    Object.entries(attributes as ReplaceCommandAttributes).forEach(
+      ([searchTerm, replaceTerm]) => {
+        if (contentLength < searchTerm.length) {
+          // It will be impossible to find the search term within this block
+          return;
+        }
+        const indexOf = (s: string, term: string, index: number): number => {
+          return s.indexOf(term, index);
+        };
+        const { original } = text;
+        for (
+          let position = indexOf(
+            original,
+            searchTerm,
+            contentRange.start.offset
+          );
+          position !== -1 &&
+          position < contentRange.end.offset - searchTerm.length;
+          position = indexOf(original, searchTerm, position + 1)
+        ) {
+          text.overwrite(position, position + searchTerm.length, replaceTerm);
+        }
+      }
+    );
+  },
+};

--- a/src/commands/ReplaceCommand.ts
+++ b/src/commands/ReplaceCommand.ts
@@ -1,24 +1,34 @@
-import { makeAttributesConformToJsonSchemaRule } from "../processor/makeAttributesConformToJsonSchemaRule";
 import { ProcessRequest } from "../processor/Processor";
 import { Command } from "./Command";
 import { removeMetaRange } from "./removeMetaRange";
 
 type ReplaceCommandAttributes = {
-  // Replace '<key>' with '<value>'
-  [searchTerm: string]: /* replaceTerm */ string;
+  terms: {
+    // Replace '<key>' with '<value>'
+    [searchTerm: string]: /* replaceTerm */ string;
+  };
 };
 
-export const ReplaceCommand: Command = {
-  rules: [
-    makeAttributesConformToJsonSchemaRule<ReplaceCommandAttributes>({
-      type: "object",
-      additionalProperties: { type: "string" },
-      minProperties: 1,
-    }),
-  ],
+export const ReplaceCommand: Command<ReplaceCommandAttributes> = {
+  attributesSchema: {
+    type: "object",
+    required: ["terms"],
+    properties: {
+      terms: {
+        type: "object",
+        minProperties: 1,
+        additionalProperties: { type: "string" },
+        required: [],
+      },
+    },
+  },
+
+  rules: [],
 
   process: ({ command, parseResult }: ProcessRequest): void => {
-    const { attributes } = command;
+    const attributes = command.attributes as
+      | ReplaceCommandAttributes
+      | undefined;
     if (attributes === undefined) {
       // TODO: error (though this can't happen if the validator was used
       return;
@@ -36,29 +46,24 @@ export const ReplaceCommand: Command = {
       return;
     }
     const contentLength = contentRange.end.offset - contentRange.start.offset;
-    Object.entries(attributes as ReplaceCommandAttributes).forEach(
-      ([searchTerm, replaceTerm]) => {
-        if (contentLength < searchTerm.length) {
-          // It will be impossible to find the search term within this block
-          return;
-        }
-        const indexOf = (s: string, term: string, index: number): number => {
-          return s.indexOf(term, index);
-        };
-        const { original } = text;
-        for (
-          let position = indexOf(
-            original,
-            searchTerm,
-            contentRange.start.offset
-          );
-          position !== -1 &&
-          position < contentRange.end.offset - searchTerm.length;
-          position = indexOf(original, searchTerm, position + 1)
-        ) {
-          text.overwrite(position, position + searchTerm.length, replaceTerm);
-        }
+    const { terms } = attributes;
+    Object.entries(terms).forEach(([searchTerm, replaceTerm]) => {
+      if (contentLength < searchTerm.length) {
+        // It will be impossible to find the search term within this block
+        return;
       }
-    );
+      const indexOf = (s: string, term: string, index: number): number => {
+        return s.indexOf(term, index);
+      };
+      const { original } = text;
+      for (
+        let position = indexOf(original, searchTerm, contentRange.start.offset);
+        position !== -1 &&
+        position < contentRange.end.offset - searchTerm.length;
+        position = indexOf(original, searchTerm, position + 1)
+      ) {
+        text.overwrite(position, position + searchTerm.length, replaceTerm);
+      }
+    });
   },
 };

--- a/src/commands/SnippetCommand.ts
+++ b/src/commands/SnippetCommand.ts
@@ -10,7 +10,7 @@ function dedentRange(
   s: MagicString,
   { contentRange }: CommandNode
 ): MagicString {
-  if (contentRange == null) {
+  if (contentRange === undefined) {
     return s;
   }
 
@@ -31,11 +31,11 @@ function dedentRange(
       return 0;
     }
     const indentLength = match[0].length;
-    if (min == null) {
+    if (min === undefined) {
       return indentLength;
     }
     return indentLength < min ? indentLength : min;
-  }, null as number | null);
+  }, undefined as number | undefined);
 
   // In this case ambiguity between 0 and null is ok
   if (!minimumIndentation) {
@@ -48,6 +48,8 @@ function dedentRange(
     s.remove(offset, offset + Math.min(line.length, minimumIndentation));
     offset += line.length + 1;
   });
+
+  return s;
 }
 
 export const SnippetCommand: Command = {
@@ -56,6 +58,11 @@ export const SnippetCommand: Command = {
     const { command, parseResult, fork } = request;
     const { source } = parseResult;
     const { contentRange } = command;
+
+    if (contentRange === undefined) {
+      // TODO: diagnostics
+      return;
+    }
 
     // Strip tags
     removeMetaRange(source.text, command);

--- a/src/commands/StateCommand.ts
+++ b/src/commands/StateCommand.ts
@@ -30,6 +30,10 @@ export const StateCommand: Command = {
     // Strip all other states
     if (stateAttribute !== command.id) {
       const { contentRange } = command;
+      if (contentRange === undefined) {
+        // TODO: diagnostics
+        return;
+      }
       source.text.remove(contentRange.start.offset, contentRange.end.offset);
     }
   },

--- a/src/commands/UncommentCommand.ts
+++ b/src/commands/UncommentCommand.ts
@@ -1,3 +1,4 @@
+import { strict as assert } from "assert";
 import { IToken } from "chevrotain";
 import { flatten } from "../parser/flatten";
 import { ProcessRequest } from "../processor/Processor";
@@ -14,7 +15,7 @@ export const UncommentCommand: Command = {
     removeMetaRange(source.text, command);
 
     const { contentRange } = command;
-    if (contentRange == null) {
+    if (contentRange == undefined) {
       return;
     }
 
@@ -30,9 +31,10 @@ export const UncommentCommand: Command = {
         (lineComment, i) =>
           i === 0 || lineComments[i - 1].startLine !== lineComment.startLine
       )
-      .forEach((lineComment) =>
+      .forEach((lineComment) => {
+        assert(lineComment.endOffset !== undefined);
         // Delete the line comment
-        source.text.remove(lineComment.startOffset, lineComment.endOffset + 1)
-      );
+        source.text.remove(lineComment.startOffset, lineComment.endOffset + 1);
+      });
   },
 };

--- a/src/commands/removeMetaRange.ts
+++ b/src/commands/removeMetaRange.ts
@@ -7,7 +7,7 @@ export function removeMetaRange(
   s: MagicString,
   { lineRange, contentRange }: { lineRange: Range; contentRange?: Range }
 ): MagicString {
-  if (contentRange == null) {
+  if (contentRange === undefined) {
     s.remove(lineRange.start.offset, lineRange.end.offset);
   } else {
     s.remove(lineRange.start.offset, contentRange.start.offset);

--- a/src/commands/replaceCommand.test.ts
+++ b/src/commands/replaceCommand.test.ts
@@ -38,7 +38,7 @@ describe("replace command", () => {
     );
   });
 
-  it("replaces keys with values", () => {
+  it("replaces keys with values", async (done) => {
     const source = new Document({
       text: `// :replace-start: {
 // "terms": {
@@ -56,15 +56,16 @@ and see test2
 
     const parseResult = bluehawk.parse(source);
     expect(parseResult.errors).toStrictEqual([]);
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     expect(files["replace.test.js"].source.text.toString())
       .toBe(`leave this alone
 go ahead and It works!
 and see --replaced--
 `);
+    done();
   });
 
-  it("is case sensitive", () => {
+  it("is case sensitive", async (done) => {
     const source = new Document({
       text: `// :replace-start: {"terms": {
 //   "Notice the Case": "It works!",
@@ -81,15 +82,16 @@ and see unchanged
 
     const parseResult = bluehawk.parse(source);
     expect(parseResult.errors.length).toBe(0);
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     expect(files["replace.test.js"].source.text.toString())
       .toBe(`leave this alone
 go ahead and notice the case
 and see unchanged
 `);
+    done();
   });
 
-  it("replaces all instances within the block", () => {
+  it("replaces all instances within the block", async (done) => {
     const source = new Document({
       text: `replaceme
 replaceme
@@ -115,7 +117,7 @@ replaceme
 
     const parseResult = bluehawk.parse(source);
     expect(parseResult.errors.length).toBe(0);
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     expect(files["replace.test.js"].source.text.toString()).toBe(`replaceme
 replaceme
 ---
@@ -130,9 +132,10 @@ replaceme
 replaceme
 replaceme
 `);
+    done();
   });
 
-  it("can't match outside of its block", () => {
+  it("can't match outside of its block", async (done) => {
     const source = new Document({
       text: `// :replace-start: {"terms": {
 //   ":replace-": "hacked"
@@ -146,13 +149,14 @@ replaceme
 
     const parseResult = bluehawk.parse(source);
     expect(parseResult.errors).toStrictEqual([]);
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     expect(files["replace.test.js"].source.text.toString()).toBe(
       `hacked hacked :rep\n`
     );
+    done();
   });
 
-  it("interoperates with remove", () => {
+  it("interoperates with remove", async (done) => {
     const source = new Document({
       text: `// :replace-start: {"terms": {
 //   "removethis": ""
@@ -173,13 +177,14 @@ andremovethisaswell
 
     const parseResult = bluehawk.parse(source);
     expect(parseResult.errors.length).toBe(0);
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     expect(files["replace.test.js"].source.text.toString())
       .toBe(`leave this alone
 1
 4
 andaswell
 `);
+    done();
   });
 
   it("doesn't unexpectedly use id as a replacement", () => {

--- a/src/commands/replaceCommand.test.ts
+++ b/src/commands/replaceCommand.test.ts
@@ -1,0 +1,183 @@
+import { Bluehawk } from "../bluehawk";
+import { Document } from "../Document";
+import { ReplaceCommand } from "./ReplaceCommand";
+import { RemoveCommand } from "./RemoveCommand";
+
+describe("replace command", () => {
+  const bluehawk = new Bluehawk();
+  bluehawk.registerCommand("replace", ReplaceCommand);
+  bluehawk.registerCommand("remove", RemoveCommand);
+
+  it("errors when no attribute list is given", () => {
+    const source = new Document({
+      text: `// :replace-start:
+// :replace-end:
+`,
+      language: "javascript",
+      path: "replace.test.js",
+    });
+
+    const parseResult = bluehawk.parse(source);
+    expect(parseResult.errors[0].message).toBe(
+      "attribute list for 'replace' command should be object"
+    );
+  });
+
+  it("errors when invalid attribute list is given", () => {
+    const source = new Document({
+      text: `// :replace-start: { "numbersNotAllowed": 1 }
+// :replace-end:
+`,
+      language: "javascript",
+      path: "replace.test.js",
+    });
+
+    const parseResult = bluehawk.parse(source);
+    expect(parseResult.errors[0].message).toBe(
+      "attribute list for 'replace' command/numbersNotAllowed should be string"
+    );
+  });
+
+  it("replaces keys with values", () => {
+    const source = new Document({
+      text: `// :replace-start: {
+//   "Replace Me": "It works!",
+//   "test2": "--replaced--"
+// }
+leave this alone
+go ahead and Replace Me
+and see test2
+// :replace-end:
+`,
+      language: "javascript",
+      path: "replace.test.js",
+    });
+
+    const parseResult = bluehawk.parse(source);
+    expect(parseResult.errors.length).toBe(0);
+    const files = bluehawk.process(parseResult);
+    expect(files["replace.test.js"].source.text.toString())
+      .toBe(`leave this alone
+go ahead and It works!
+and see --replaced--
+`);
+  });
+
+  it("is case sensitive", () => {
+    const source = new Document({
+      text: `// :replace-start: {
+//   "Notice the Case": "It works!",
+//   "UNCHANGED": "changed"
+// }
+leave this alone
+go ahead and notice the case
+and see unchanged
+// :replace-end:
+`,
+      language: "javascript",
+      path: "replace.test.js",
+    });
+
+    const parseResult = bluehawk.parse(source);
+    expect(parseResult.errors.length).toBe(0);
+    const files = bluehawk.process(parseResult);
+    expect(files["replace.test.js"].source.text.toString())
+      .toBe(`leave this alone
+go ahead and notice the case
+and see unchanged
+`);
+  });
+
+  it("replaces all instances within the block", () => {
+    const source = new Document({
+      text: `replaceme
+replaceme
+---
+// :replace-start: {
+//   "replaceme": "replaced"
+// }
+replaceme
+left alone
+replaceme
+replaceme
+left alone
+and replaceme
+// :replace-end:
+---
+replaceme
+replaceme
+replaceme
+`,
+      language: "javascript",
+      path: "replace.test.js",
+    });
+
+    const parseResult = bluehawk.parse(source);
+    expect(parseResult.errors.length).toBe(0);
+    const files = bluehawk.process(parseResult);
+    expect(files["replace.test.js"].source.text.toString()).toBe(`replaceme
+replaceme
+---
+replaced
+left alone
+replaced
+replaced
+left alone
+and replaced
+---
+replaceme
+replaceme
+replaceme
+`);
+  });
+
+  it("can't match outside of its block", () => {
+    const source = new Document({
+      text: `// :replace-start: {
+//   ":replace-": "hacked"
+// }
+:replace- :replace- :rep
+:replace-end:
+`,
+      language: "javascript",
+      path: "replace.test.js",
+    });
+
+    const parseResult = bluehawk.parse(source);
+    expect(parseResult.errors).toStrictEqual([]);
+    const files = bluehawk.process(parseResult);
+    expect(files["replace.test.js"].source.text.toString()).toBe(
+      `hacked hacked :rep\n`
+    );
+  });
+
+  it("interoperates with remove", () => {
+    const source = new Document({
+      text: `// :replace-start: {
+//   "removethis": ""
+// }
+leave this alone
+removethis1
+// :remove-start:
+removethis2
+removethis3
+// :remove-end:
+removethis4
+andremovethisaswell
+// :replace-end:
+`,
+      language: "javascript",
+      path: "replace.test.js",
+    });
+
+    const parseResult = bluehawk.parse(source);
+    expect(parseResult.errors.length).toBe(0);
+    const files = bluehawk.process(parseResult);
+    expect(files["replace.test.js"].source.text.toString())
+      .toBe(`leave this alone
+1
+4
+andaswell
+`);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,10 +28,10 @@ async function run(): Promise<void> {
     .help("h")
     .alias("h", "help").argv;
 
-  let ignores: string[];
-  if (typeof params.ignores == "string") {
-    ignores = (params.ignores as string).split(",");
-  }
+  const ignores: string[] =
+    typeof params.ignores === "string" || params.ignores instanceof String
+      ? (params.ignores as string).split(",")
+      : [];
 
   const { snippets } = params;
 
@@ -45,7 +45,7 @@ async function run(): Promise<void> {
     [path: string]: boolean;
   } = {};
 
-  let onBinaryFile: (path: string) => void = undefined;
+  let onBinaryFile: ((path: string) => void) | undefined = undefined;
   // Output snippet files -- exclude full state files
   if (snippets) {
     listeners.push((result: ParseResult): void | Promise<void> => {

--- a/src/io/messageHandler.ts
+++ b/src/io/messageHandler.ts
@@ -39,7 +39,7 @@ export class MessageHandler {
 }
 
 class DiagnosticMessage {
-  messageType: string;
+  messageType = "";
   prefix = "";
   message: string[];
   constructor(...message: string[]) {
@@ -48,21 +48,21 @@ class DiagnosticMessage {
 }
 
 export class WarningMessage extends DiagnosticMessage {
-  messageType: "warning";
-  prefix: "\n⚠️\t";
+  messageType = "warning";
+  prefix = "\n⚠️\t";
 }
 
 export class ImportantMessage extends DiagnosticMessage {
-  messageType: "important";
-  prefix: "\n❗\t";
+  messageType = "important";
+  prefix = "\n❗\t";
 }
 
 export class InfoMessage extends DiagnosticMessage {
-  messageType: "info";
+  messageType = "info";
 }
 
 export class ErrorMessage extends DiagnosticMessage {
-  messageType: "error";
+  messageType = "error";
 }
 
 type NonErrorMessage = WarningMessage | ImportantMessage | InfoMessage;

--- a/src/io/parseSource.ts
+++ b/src/io/parseSource.ts
@@ -10,6 +10,7 @@ import { RemoveCommand } from "../commands/RemoveCommand";
 import { StateCommand } from "../commands/StateCommand";
 import { UncommentCommand } from "../commands/UncommentCommand";
 import { isBinary } from "istextorbinary";
+import { ReplaceCommand } from "../commands/ReplaceCommand";
 
 async function fileEntry(
   source: string,
@@ -84,6 +85,7 @@ export async function main(
 ): Promise<void> {
   const bluehawk = new Bluehawk();
   bluehawk.registerCommand("code-block", SnippetCommand);
+  bluehawk.registerCommand("replace", ReplaceCommand);
   bluehawk.registerCommand("snippet", SnippetCommand);
   bluehawk.registerCommand("remove", RemoveCommand);
 
@@ -95,7 +97,7 @@ export async function main(
 
   // uncomment the block in the state
   bluehawk.registerCommand("state-uncomment", {
-    rules: [],
+    rules: [...StateCommand.rules],
     process: (request: ProcessRequest): void => {
       UncommentCommand.process(request);
       StateCommand.process(request);

--- a/src/io/parseSource.ts
+++ b/src/io/parseSource.ts
@@ -13,14 +13,12 @@ import { isBinary } from "istextorbinary";
 
 async function fileEntry(
   source: string,
-  ignores?: string[]
+  ignoresOrUndefined?: string[]
 ): Promise<string[]> {
   return new Promise((resolve, reject) => {
     const ig = ignore();
-    if (!ignores) {
-      ignores = [];
-    }
-    function traverse(source: string, fileArray = []): string[] {
+    const ignores = ignoresOrUndefined ?? [];
+    function traverse(source: string, fileArray = [] as string[]): string[] {
       let files: string[] = [];
       if (fs.lstatSync(path.resolve(source)).isFile()) {
         return [source];

--- a/src/parser/CommandNode.ts
+++ b/src/parser/CommandNode.ts
@@ -111,6 +111,31 @@ export class CommandNode {
     this.commandName = commandName;
     this.newlines = [];
     this.lineComments = [];
+    // FIXME: ranges should always be valid, so pass them in the constructor
+    this.range = {
+      start: {
+        column: -1,
+        line: -1,
+        offset: -1,
+      },
+      end: {
+        column: -1,
+        line: -1,
+        offset: -1,
+      },
+    };
+    this.lineRange = {
+      start: {
+        column: -1,
+        line: -1,
+        offset: -1,
+      },
+      end: {
+        column: -1,
+        line: -1,
+        offset: -1,
+      },
+    };
     this.addTokensFromContext(context);
     if (parentToAttachTo !== undefined) {
       this._context = [...parentToAttachTo._context];

--- a/src/parser/CommandNode.ts
+++ b/src/parser/CommandNode.ts
@@ -3,6 +3,9 @@ import { IToken } from "chevrotain";
 import { Range } from "../Range";
 import { CommandNodeContext } from "./visitor/makeCstVisitor";
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type CommandNodeAttributes = { [member: string]: any };
+
 interface VisitorContext {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
@@ -38,7 +41,7 @@ export class CommandNode {
 
   // Attributes come from JSON and their schema depends on the command.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  attributes?: { [member: string]: any };
+  attributes?: CommandNodeAttributes;
 
   // Potentially useful tokens contained in the node
   newlines: IToken[];
@@ -96,7 +99,6 @@ export class CommandNode {
   // other nodes in the document.
   static rootCommand(): CommandNode {
     const command = new CommandNode("__root__", {});
-    command.attributes = new Map();
     command.children = [];
     return command;
   }
@@ -110,8 +112,9 @@ export class CommandNode {
     this.newlines = [];
     this.lineComments = [];
     this.addTokensFromContext(context);
-    if (parentToAttachTo != null) {
+    if (parentToAttachTo !== undefined) {
       this._context = [...parentToAttachTo._context];
+      assert(parentToAttachTo.children);
       parentToAttachTo.children.push(this);
     }
   }

--- a/src/parser/ParseResult.ts
+++ b/src/parser/ParseResult.ts
@@ -2,7 +2,7 @@ import { CommandNode } from "./CommandNode";
 import { Document } from "../Document";
 import { BluehawkError } from "../BluehawkError";
 
-export class ParseResult {
+export interface ParseResult {
   errors: BluehawkError[];
   commandNodes: CommandNode[];
   source: Document;

--- a/src/parser/RootParser.ts
+++ b/src/parser/RootParser.ts
@@ -47,7 +47,7 @@ annotatedText
   : (chunk)*
 
 attributeList
-  : AttributeListStart (AttributeListStart | AttributeListEnd | JsonStringLiteral | Newline | LineComment)* AttributeListEnd
+  : AttributeListStart (attributeList | JsonStringLiteral | Newline | LineComment)* AttributeListEnd
 
 blockCommand
   : (LineComment)? CommandStart (commandAttribute)? Newline (chunk)* (LineComment)* CommandEnd

--- a/src/parser/RootParser.ts
+++ b/src/parser/RootParser.ts
@@ -1,3 +1,4 @@
+import { strict as assert } from "assert";
 import { CstNode, CstParser, Lexer, TokenType } from "chevrotain";
 import { makeLexer } from "./lexer/makeLexer";
 import { makeRootMode } from "./lexer/makeRootMode";
@@ -21,17 +22,6 @@ import { ErrorMessageProvider } from "./ErrorMessageProvider";
 import { BluehawkError } from "../BluehawkError";
 
 // See https://sap.github.io/chevrotain/docs/tutorial/step2_parsing.html
-
-type Rule = (idx?: number) => CstNode;
-
-interface ParserResult {
-  cst?: CstNode;
-  errors: BluehawkError[];
-}
-
-export interface IParser {
-  parse(text: string): ParserResult;
-}
 
 // Comment awareness prevents bluehawk from outputting half-commented code
 // blocks.
@@ -83,20 +73,31 @@ pushParser
 † = if canNestBlockComments
 */
 
+type Rule = (idx?: number) => CstNode;
+
+interface ParserResult {
+  cst?: CstNode;
+  errors: BluehawkError[];
+}
+
+export interface IParser {
+  parse(text: string): ParserResult;
+}
+
 // While the lexer defines the tokens of the language, the parser defines the
 // syntax.
 export class RootParser extends CstParser implements IParser {
   lexer: Lexer;
 
-  annotatedText: Rule;
-  chunk: Rule;
-  blockCommand: Rule;
-  command: Rule;
-  commandAttribute: Rule;
-  blockComment: Rule;
-  lineComment: Rule;
-  attributeList: Rule;
-  pushParser: Rule;
+  annotatedText: Rule = UndefinedRule;
+  chunk: Rule = UndefinedRule;
+  blockCommand: Rule = UndefinedRule;
+  command: Rule = UndefinedRule;
+  commandAttribute: Rule = UndefinedRule;
+  blockComment: Rule = UndefinedRule;
+  lineComment: Rule = UndefinedRule;
+  attributeList: Rule = UndefinedRule;
+  pushParser: Rule = UndefinedRule;
 
   constructor(languageTokens: TokenType[]) {
     super(makeRootMode(languageTokens), {
@@ -275,4 +276,11 @@ export class RootParser extends CstParser implements IParser {
       ],
     };
   }
+}
+
+// Chevrotain assigns the rules after construction. Initializing rule properties
+// with this rule quashes the "Property 'annotatedText' has no initializer and
+// is not definitely assigned in the constructor." error.
+function UndefinedRule(): CstNode {
+  assert(false);
 }

--- a/src/parser/lexer/makeBlockCommentTokens.ts
+++ b/src/parser/lexer/makeBlockCommentTokens.ts
@@ -11,7 +11,7 @@ export function makeBlockCommentTokens(
   endPattern: RegExp,
   configuration?: BlockCommentTokenConfiguration
 ): [TokenType, TokenType] {
-  const tokens = [
+  const tokens: [TokenType, TokenType] = [
     createToken({
       name: "BlockCommentStart",
       label: `BlockCommentStart(${startPattern})`,

--- a/src/parser/lexer/makePayloadPattern.ts
+++ b/src/parser/lexer/makePayloadPattern.ts
@@ -31,7 +31,7 @@ export function makePayloadPattern<PayloadType>(
       offset: number,
       tokens: IToken[],
       groups: { [groupName: string]: IToken[] }
-    ): RegExpExecArray => {
+    ): RegExpExecArray | null => {
       // start the search at the offset
       pattern.lastIndex = offset;
 

--- a/src/parser/lexer/tokenCategoryFilter.ts
+++ b/src/parser/lexer/tokenCategoryFilter.ts
@@ -8,7 +8,7 @@ export function tokenCategoryFilter(
 ): TokenType[] {
   return tokens.filter(
     (token) =>
-      token.CATEGORIES.find((category) => categories.includes(category)) !==
+      token.CATEGORIES?.find((category) => categories.includes(category)) !==
       undefined
   );
 }

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -205,6 +205,7 @@ bad second line
       expect(result.tokens[0].image).toBe(":block-command-start:");
       expect(result.tokens[1].image).toBe("{");
       parser.input = result.tokens.slice(1); // CommandStart required to get lexer in JSON mode
+      expect(parser.attributeList).toBeDefined();
       parser.attributeList();
       expect(parser.errors).toStrictEqual([]);
     });

--- a/src/parser/visitor/makeCstVisitor.ts
+++ b/src/parser/visitor/makeCstVisitor.ts
@@ -141,7 +141,7 @@ export function makeCstVisitor(
 
   interface PushParserContext {
     PushParser: IToken[];
-    PopParser: IToken[];
+    [correspondingPopParserName: string]: IToken[];
   }
 
   // Tuple passed to visitor methods. All errors go to the top level. Visitor
@@ -166,7 +166,7 @@ export function makeCstVisitor(
     // The entrypoint for the visitor.
     visit(node: CstNode, source: Document): VisitorResult {
       const parent = CommandNode.rootCommand();
-      const errors = [];
+      const errors: BluehawkError[] = [];
       this.$visit([node], { errors, parent, source });
       return {
         errors,
@@ -513,6 +513,7 @@ export function makeCstVisitor(
       // We need to know exactly which PopParser token we are looking for.
       const PopParser = context[endToken.name][0];
       assert(PopParser);
+      assert(PopParser.endOffset);
 
       const startLocation = includePushTokenInSubstring
         ? locationFromToken(PushParser)

--- a/src/parser/visitor/multilang.test.ts
+++ b/src/parser/visitor/multilang.test.ts
@@ -25,7 +25,7 @@ CC
     for (let i = 1; i < 4; ++i) {
       expect(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        Object.keys((parseResult.cst.children.chunk[i] as any).children)[0]
+        Object.keys((parseResult.cst?.children.chunk[i] as any).children)[0]
       ).toBe("blockComment");
     }
   });
@@ -72,6 +72,10 @@ describe("multilang", () => {
 # :command2:
 `);
     expect(parseResult.errors).toStrictEqual([]);
+    expect(parseResult.cst).toBeDefined();
+    if (parseResult.cst === undefined) {
+      return;
+    }
     const result = visitor.visit(parseResult.cst, someSource);
     expect(result.errors).toStrictEqual([]);
     expect(
@@ -102,6 +106,10 @@ describe("multilang", () => {
 # :command5:
 `);
     expect(parseResult.errors).toStrictEqual([]);
+    expect(parseResult.cst).toBeDefined();
+    if (parseResult.cst === undefined) {
+      return;
+    }
     const result = visitor.visit(parseResult.cst, someSource);
     expect(result.errors).toStrictEqual([]);
     expect(
@@ -131,6 +139,10 @@ describe("multilang", () => {
 ?>
 `);
     expect(parseResult.errors).toStrictEqual([]);
+    expect(parseResult.cst).toBeDefined();
+    if (parseResult.cst === undefined) {
+      return;
+    }
     const result = visitor.visit(parseResult.cst, someSource);
     expect(result.errors[0].message).toContain(
       "blockComment: After Newline, expected BlockCommentEnd but found EOF"
@@ -161,6 +173,10 @@ describe("multilang", () => {
 :command2:
 `);
     const visitor = makeCstVisitor(markdownParser, getParser);
+    expect(parseResult.cst).toBeDefined();
+    if (parseResult.cst === undefined) {
+      return;
+    }
     const result = visitor.visit(parseResult.cst, someSource);
     expect(result.errors).toStrictEqual([]);
     expect(

--- a/src/parser/visitor/visitor.test.ts
+++ b/src/parser/visitor/visitor.test.ts
@@ -111,8 +111,10 @@ annotated text
     const result = visitor.visit(cst, source);
     expect(result.errors).toStrictEqual([]);
     expect(result.commandNodes.length).toBe(1);
-    expect(result.commandNodes[0].children.length).toBe(1);
-    expect(result.commandNodes[0].children[0].children.length).toBe(2);
+    expect((result.commandNodes[0].children ?? []).length).toBe(1);
+    expect(
+      (result.commandNodes[0].children ?? [])[0].children?.length ?? 0
+    ).toBe(2);
   });
 
   it("supports id commands", () => {
@@ -128,7 +130,7 @@ annotated text
     const result = visitor.visit(cst, source);
     expect(result.errors).toStrictEqual([]);
     expect(result.commandNodes[0].commandName).toBe("A");
-    expect(result.commandNodes[0].children.length).toBe(0);
+    expect((result.commandNodes[0].children ?? []).length).toBe(0);
     expect(result.commandNodes[0].id).toBe("label");
   });
 
@@ -251,12 +253,24 @@ annotated text
     const a = result.commandNodes[0];
     expect(a.commandName).toBe("a");
     expect(a.inContext).toBe("lineComment");
+    expect(a.children).toBeDefined();
+    if (a.children === undefined) {
+      return;
+    }
     const b = a.children[0];
     expect(b.commandName).toBe("b");
     expect(b.inContext).toBe("lineComment");
+    expect(b.children).toBeDefined();
+    if (b.children === undefined) {
+      return;
+    }
     const c = b.children[0];
     expect(c.commandName).toBe("c");
     expect(c.inContext).toBe("blockComment");
+    expect(c.children).toBeDefined();
+    if (c.children === undefined) {
+      return;
+    }
     const d = c.children[0];
     expect(d.commandName).toBe("d");
     expect(d.inContext).toBe("blockComment");
@@ -309,6 +323,10 @@ the quick brown fox jumped
     expect(a.commandName).toBe("a");
     // contentRange describes the range of the block's content, including sub-commands
     // but not the current start/endcommands
+    expect(result.commandNodes[0].contentRange).toBeDefined();
+    if (result.commandNodes[0].contentRange === undefined) {
+      return;
+    }
     expect(result.commandNodes[0].contentRange.start.line).toBe(3);
     expect(result.commandNodes[0].contentRange.start.column).toBe(1);
     expect(result.commandNodes[0].contentRange.start.offset).toBe(14);
@@ -350,6 +368,10 @@ and again
     expect(a.range.end.offset).toBe(124);
     // contentRange describes the range of the block's content, including sub-commands
     // but not the current start/endcommands
+    expect(a.contentRange).toBeDefined();
+    if (a.contentRange === undefined) {
+      return;
+    }
     expect(a.contentRange.start.line).toBe(3);
     expect(a.contentRange.start.column).toBe(1);
     expect(a.contentRange.start.offset).toBe(14);
@@ -357,7 +379,7 @@ and again
     expect(a.contentRange.end.column).toBe(1);
     expect(a.contentRange.end.offset).toBe(115);
 
-    const b = result.commandNodes[0].children[0];
+    const b = (result.commandNodes[0].children ?? [])[0];
     expect(b.commandName).toBe("b");
     // range describes the total block range, from the start of the first command
     // to the end of the last command
@@ -369,6 +391,10 @@ and again
     expect(b.range.end.offset).toBe(113);
     // contentRange describes the range of the block's content, including sub-commands
     // but not the current start/endcommands
+    expect(b.contentRange).toBeDefined();
+    if (b.contentRange === undefined) {
+      return;
+    }
     expect(b.contentRange.start.line).toBe(5);
     expect(b.contentRange.start.column).toBe(1);
     expect(b.contentRange.start.offset).toBe(54);
@@ -376,7 +402,7 @@ and again
     expect(b.contentRange.end.column).toBe(1);
     expect(b.contentRange.end.offset).toBe(104);
 
-    const c = result.commandNodes[0].children[0].children[0];
+    const c = ((result.commandNodes[0].children ?? [])[0].children ?? [])[0];
     expect(c.commandName).toBe("c");
     // range describes the total block range, from the start of the first command
     // to the end of the last command
@@ -388,6 +414,10 @@ and again
     expect(c.range.end.offset).toBe(102);
     // contentRange describes the range of the block's content, including sub-commands
     // but not the current start/endcommands
+    expect(c.contentRange).toBeDefined();
+    if (c.contentRange === undefined) {
+      return;
+    }
     expect(c.contentRange.start.line).toBe(7);
     expect(c.contentRange.start.column).toBe(1);
     expect(c.contentRange.start.offset).toBe(83);
@@ -538,6 +568,10 @@ line 10 :a-end:
     expect(result.errors).toStrictEqual([]);
     expect(result.commandNodes.length).toBe(1);
     const lines = tokenString.split("\n");
+    expect(result.commandNodes[0].contentRange).toBeDefined();
+    if (result.commandNodes[0].contentRange === undefined) {
+      return;
+    }
     expect(result.commandNodes[0].contentRange.start.line).toBe(9);
     expect(lines[result.commandNodes[0].contentRange.start.line - 1]).toBe(
       "line 9 -- some more content"
@@ -575,7 +609,7 @@ line 10 :a-end:
       result.commandNodes[0].lineComments.map((token) => token.startLine)
     ).toStrictEqual([3]);
     expect(
-      result.commandNodes[0].children[0].lineComments.map(
+      (result.commandNodes[0].children ?? [])[0].lineComments.map(
         (token) => token.startLine
       )
     ).toStrictEqual([5]);
@@ -603,7 +637,10 @@ c2345678 :a-start:
     expect(lines[2].length).toBe(19);
     expect(lines[3].length).toBe(3);
     expect(lines[4].length).toBe(11);
-
+    expect(result.commandNodes[0].contentRange).toBeDefined();
+    if (result.commandNodes[0].contentRange === undefined) {
+      return;
+    }
     expect(result.commandNodes[0].contentRange.start.line).toBe(4);
     expect(result.commandNodes[0].contentRange.start.column).toBe(1);
 

--- a/src/processor/Processor.ts
+++ b/src/processor/Processor.ts
@@ -1,7 +1,7 @@
 import { ParseResult } from "../parser/ParseResult";
 import { Document, CommandAttributes } from "../Document";
 import { CommandNode } from "../parser/CommandNode";
-import { Command } from "../commands/Command";
+import { AnyCommand } from "../commands/Command";
 
 export type BluehawkFiles = { [pathName: string]: ParseResult };
 
@@ -17,7 +17,7 @@ export interface ProcessRequest {
   command: CommandNode;
 }
 
-export type CommandProcessors = Record<string, Command>;
+export type CommandProcessors = Record<string, AnyCommand>;
 
 export type Listener = (result: ParseResult) => void | Promise<void>;
 
@@ -113,7 +113,7 @@ export class Processor {
     }, [] as Promise<void>[]);
   };
 
-  registerCommand(name: string, command: Command): void {
+  registerCommand(name: string, command: AnyCommand): void {
     this.processors[name] = command;
   }
 }

--- a/src/processor/makeAttributesConformToJsonSchemaRule.test.ts
+++ b/src/processor/makeAttributesConformToJsonSchemaRule.test.ts
@@ -1,0 +1,144 @@
+import { JSONSchemaType } from "ajv";
+import { CommandNode, CommandNodeAttributes } from "../parser/CommandNode";
+import { Range } from "../Range";
+import { makeAttributesConformToJsonSchemaRule } from "./makeAttributesConformToJsonSchemaRule";
+import { ValidateCstResult } from "./validator";
+
+describe("makeAttributesConformToJsonSchemaRule", () => {
+  const mockRange: Range = {
+    start: {
+      column: 1,
+      line: 1,
+      offset: 0,
+    },
+    end: {
+      column: 10,
+      line: 1,
+      offset: 9,
+    },
+  };
+  const makeValidateCstResult = (): ValidateCstResult => {
+    return {
+      commandsById: new Map(),
+      errors: [],
+    };
+  };
+
+  const mockCommandNode = (attributes?: CommandNodeAttributes): CommandNode => {
+    const node = CommandNode.rootCommand();
+    node.commandName = "mock";
+    node.range = mockRange;
+    node.attributes = attributes;
+    return node;
+  };
+
+  type MyType = {
+    requiredNumber: number;
+    notNegative: number;
+  };
+
+  it("reports errors", () => {
+    const rule = makeAttributesConformToJsonSchemaRule<MyType>({
+      type: "object",
+      properties: {
+        requiredNumber: { type: "number" },
+        notNegative: { type: "number", minimum: 0 },
+      },
+      required: ["requiredNumber"],
+      additionalProperties: false,
+    });
+    const result = makeValidateCstResult();
+    rule(
+      mockCommandNode({
+        // missing requiredNumber
+        notNegative: -1, // invalid value
+      }),
+      result
+    );
+    expect(result.errors).toStrictEqual([
+      {
+        component: "validator",
+        location: {
+          column: 1,
+          line: 1,
+          offset: 0,
+        },
+        message:
+          "attribute list for 'mock' command should have required property 'requiredNumber'",
+      },
+    ]);
+  });
+
+  it("reports errors one at a time", () => {
+    const rule = makeAttributesConformToJsonSchemaRule<MyType>({
+      type: "object",
+      properties: {
+        requiredNumber: { type: "number" },
+        notNegative: { type: "number", minimum: 0 },
+      },
+      required: ["requiredNumber"],
+      additionalProperties: false,
+    });
+    let result = makeValidateCstResult();
+    rule(
+      mockCommandNode({
+        // missing requiredNumber
+        notNegative: -1,
+      }),
+      result
+    );
+    expect(result.errors.map((error) => error.message)).toStrictEqual([
+      "attribute list for 'mock' command should have required property 'requiredNumber'",
+    ]);
+    result = makeValidateCstResult();
+    rule(
+      mockCommandNode({
+        // fix first issue
+        requiredNumber: 1,
+        notNegative: -1,
+      }),
+      result
+    );
+    expect(result.errors.map((error) => error.message)).toStrictEqual([
+      "attribute list for 'mock' command/notNegative should be >= 0",
+    ]);
+    result = makeValidateCstResult();
+    rule(
+      mockCommandNode({
+        requiredNumber: 1,
+        // fix second issue
+        notNegative: 1,
+      }),
+      result
+    );
+    expect(result.errors.map((error) => error.message)).toStrictEqual([]);
+  });
+
+  it("reports errors on undefined attributes", () => {
+    const result = makeValidateCstResult();
+    const rule = makeAttributesConformToJsonSchemaRule<MyType>({
+      type: "object",
+      properties: {
+        requiredNumber: { type: "number" },
+        notNegative: { type: "number", minimum: 0 },
+      },
+      required: ["requiredNumber"],
+      additionalProperties: false,
+    });
+    rule(mockCommandNode(), result);
+    expect(result.errors[0].message).toBe(
+      "attribute list for 'mock' command should be object"
+    );
+  });
+
+  it("throws on malformed schema", () => {
+    expect(() => {
+      makeAttributesConformToJsonSchemaRule(({
+        type: "badType",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any) as JSONSchemaType<MyType>);
+    }).toThrow(
+      "schema is invalid: data/type should be equal to one of the allowed values, data/type should be array, data/type should match some schema in anyOf"
+    );
+  });
+});

--- a/src/processor/makeAttributesConformToJsonSchemaRule.test.ts
+++ b/src/processor/makeAttributesConformToJsonSchemaRule.test.ts
@@ -34,7 +34,7 @@ describe("makeAttributesConformToJsonSchemaRule", () => {
 
   type MyType = {
     requiredNumber: number;
-    notNegative: number;
+    notNegative?: number;
   };
 
   it("reports errors", () => {
@@ -42,7 +42,7 @@ describe("makeAttributesConformToJsonSchemaRule", () => {
       type: "object",
       properties: {
         requiredNumber: { type: "number" },
-        notNegative: { type: "number", minimum: 0 },
+        notNegative: { type: "number", minimum: 0, nullable: true },
       },
       required: ["requiredNumber"],
       additionalProperties: false,
@@ -74,7 +74,7 @@ describe("makeAttributesConformToJsonSchemaRule", () => {
       type: "object",
       properties: {
         requiredNumber: { type: "number" },
-        notNegative: { type: "number", minimum: 0 },
+        notNegative: { type: "number", minimum: 0, nullable: true },
       },
       required: ["requiredNumber"],
       additionalProperties: false,
@@ -120,7 +120,7 @@ describe("makeAttributesConformToJsonSchemaRule", () => {
       type: "object",
       properties: {
         requiredNumber: { type: "number" },
-        notNegative: { type: "number", minimum: 0 },
+        notNegative: { type: "number", minimum: 0, nullable: true },
       },
       required: ["requiredNumber"],
       additionalProperties: false,

--- a/src/processor/makeAttributesConformToJsonSchemaRule.ts
+++ b/src/processor/makeAttributesConformToJsonSchemaRule.ts
@@ -1,12 +1,12 @@
 import { CommandNode } from "../parser/CommandNode";
-import Ajv, { JSONSchemaType } from "ajv";
+import Ajv, { JSONSchemaType, AnySchema } from "ajv";
 import { Rule, ValidateCstResult } from "./validator";
 
 const ajv = new Ajv();
 
 // Creates a rule that checks attributes against the given JSON schema.
-export const makeAttributesConformToJsonSchemaRule = <Type>(
-  schema: JSONSchemaType<Type>
+export const makeAttributesConformToJsonSchemaRule = <Type = unknown>(
+  schema: JSONSchemaType<Type> | AnySchema
 ): Rule => {
   const validate = ajv.compile(schema);
   return (

--- a/src/processor/makeAttributesConformToJsonSchemaRule.ts
+++ b/src/processor/makeAttributesConformToJsonSchemaRule.ts
@@ -1,0 +1,28 @@
+import { CommandNode } from "../parser/CommandNode";
+import Ajv, { JSONSchemaType } from "ajv";
+import { Rule, ValidateCstResult } from "./validator";
+
+const ajv = new Ajv();
+
+// Creates a rule that checks attributes against the given JSON schema.
+export const makeAttributesConformToJsonSchemaRule = <Type>(
+  schema: JSONSchemaType<Type>
+): Rule => {
+  const validate = ajv.compile(schema);
+  return (
+    { attributes, range, commandName }: CommandNode,
+    result: ValidateCstResult
+  ) => {
+    if (validate(attributes)) {
+      return;
+    }
+    result.errors.push({
+      component: "validator",
+      location: range.start,
+      message: ajv.errorsText(validate.errors, {
+        separator: "\n",
+        dataVar: `attribute list for '${commandName}' command`,
+      }),
+    });
+  };
+};

--- a/src/processor/validator.ts
+++ b/src/processor/validator.ts
@@ -2,6 +2,7 @@ import { CommandNode } from "../parser/CommandNode";
 import { BluehawkError } from "../BluehawkError";
 import { flatten } from "../parser/flatten";
 import { CommandProcessors } from "./Processor";
+import { makeAttributesConformToJsonSchemaRule } from "./makeAttributesConformToJsonSchemaRule";
 
 export interface ValidateCstResult {
   errors: BluehawkError[];
@@ -30,6 +31,14 @@ export function validateCommands(
       // TODO: warn unknown command
       return;
     }
+
+    if (processor.attributesSchema !== undefined) {
+      const attributeSchemaValidator = makeAttributesConformToJsonSchemaRule(
+        processor.attributesSchema
+      );
+      attributeSchemaValidator(commandNode, validateResult);
+    }
+
     processor.rules.forEach((rule) => {
       rule(commandNode, validateResult);
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "esModuleInterop": true,
     "lib": ["ES2020"],
     "downlevelIteration": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "strict": true
   },
   "sourceMap": true,
   "include": ["./src/**/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "target": "ES5",
     "esModuleInterop": true,
     "lib": ["ES2020"],
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "strictNullChecks": true
   },
   "sourceMap": true,
   "include": ["./src/**/*"]


### PR DESCRIPTION
- Implements attribute schema conformity checker. This allows you to define validator rules that check that the attribute block after a command actually matches a given JSON schema.
- JSON schema library AJV requires strict null checking for nice typescript features, so enabled that -- resulting in lots of conflicts with Chevrotain nullability
- Enabled TypeScript strict mode while we're at it
- Implements "replace", which takes a record of search terms to replace terms and replaces all in the block.
- Fixes a bug in attribute lists where comments were not stripped from inner JSON objects.