### PR TITLE
Implement basic plugin system

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,36 @@ All commands that end with `-start` have a corresponding `-end` command. You use
 start and end commands to delineate blocks of content. Generally, the command
 operates on the content within the block.
 
+## Plugins
+
+You can add commands and listeners by creating a JS file or node project that
+implements the register() function:
+
+```js
+// myPlugin.js
+exports.register = (bluehawk) => {
+  // Register a new command, :my-command:
+  bluehawk.registerCommand("my-command", {
+    rules: [],
+    process: (request) => {
+      // Execute command
+    }
+  });
+
+  // Register a document listener
+  bluehawk.subscribe((finishedDocument) => {
+    // Do something with finishedDocument
+  });
+};
+```
+
+Usage:
+
+```shell
+bluehawk --plugin ./myPlugin --source source.txt
+```
+
+You can pass the --plugin flag multiple times to load different plugins.
 
 ## Running Tests
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,11 @@ async function run(): Promise<void> {
     .command("--ignores", "A glob list of patterns to ignore")
     .command("--state", "Which state to render")
     .boolean("snippets")
-    .describe("snippets", "Output snippet files only")
+    .string("plugin")
+    .describe({
+      snippets: "Output snippet files only",
+      plugin: "Path to plugin JS file",
+    })
     .example(
       "$0 -s ./foo.js -d ./output/",
       "Parse the foo.js file and output results in the output/ directory."
@@ -155,7 +159,7 @@ async function run(): Promise<void> {
 
   const source = params.source as string;
   const destination = params.destination as string;
-  await bhp.main(source, ignores, listeners, onBinaryFile);
+  await bhp.main(source, ignores, listeners, onBinaryFile, params.plugin);
 
   if (params.state && Object.keys(stateVersionWrittenForPath).length === 0) {
     console.warn(


### PR DESCRIPTION
You can add commands and listeners by creating a JS file (or node project) that implements the register() function.

```js
// plugin.js
exports.register = (bluehawk) => {
  bluehawk.registerCommand("my-command", {
    rules: [],
    process: (request) => {
      console.log("gotcha")
    }
  });
};
```
Usage:
```shell
bluehawk --plugin ./plugin --source source.txt
```
You can pass the `--plugin` flag multiple times to load different plugins.

This is a rudimentary first pass. Error handling could be improved, and it might be nice to allow users to register binary file listeners.
