### PR TITLE
Async commands & listeners

### DIFF
--- a/src/bluehawk.ts
+++ b/src/bluehawk.ts
@@ -59,7 +59,7 @@ export class Bluehawk {
   }
 
   // Executes the commands on the given source. Use subscribe() to get results.
-  process = (parseResult: ParseResult): BluehawkFiles => {
+  process = async (parseResult: ParseResult): Promise<BluehawkFiles> => {
     return this.processor.process(parseResult);
   };
 

--- a/src/commands/Command.ts
+++ b/src/commands/Command.ts
@@ -9,5 +9,5 @@ export interface Command {
   rules: Rule[];
 
   // Implementation of the command
-  process: (request: ProcessRequest) => void;
+  process: (request: ProcessRequest) => void | Promise<void>;
 }

--- a/src/commands/SnippetCommand.ts
+++ b/src/commands/SnippetCommand.ts
@@ -53,7 +53,7 @@ function dedentRange(
 export const SnippetCommand: Command = {
   rules: [hasId, idIsUnique],
   process: (request: ProcessRequest): void => {
-    const { command, processor, parseResult } = request;
+    const { command, parseResult, fork } = request;
     const { source } = parseResult;
     const { contentRange } = command;
 
@@ -70,7 +70,7 @@ export const SnippetCommand: Command = {
     dedentRange(clonedSnippet, command);
 
     // Fork subset code block to another file
-    processor.fork({
+    fork({
       parseResult: {
         commandNodes: command.children ?? [],
         errors: [],

--- a/src/commands/StateCommand.ts
+++ b/src/commands/StateCommand.ts
@@ -6,7 +6,7 @@ import { hasId } from "../processor/validator";
 export const StateCommand: Command = {
   rules: [hasId],
   process: (request: ProcessRequest): void => {
-    const { command, processor, parseResult } = request;
+    const { command, fork, parseResult } = request;
     const { source } = parseResult;
 
     // Strip tags
@@ -16,7 +16,7 @@ export const StateCommand: Command = {
 
     if (stateAttribute === undefined) {
       // We are not processing in a state file, so start one
-      processor.fork({
+      fork({
         parseResult,
         newModifier: `state.${command.id}`,
         newAttributes: {

--- a/src/commands/removeCommand.test.ts
+++ b/src/commands/removeCommand.test.ts
@@ -34,7 +34,7 @@ line 3`);
     expect(s.toString()).toBe(`line 3`);
   });
 
-  it("strips text", () => {
+  it("strips text", async (done) => {
     const singleInput = `const bar = "foo"
 
 // :remove-start:
@@ -54,14 +54,15 @@ console.log(bar);
     });
 
     const parseResult = bluehawk.parse(source);
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     expect(files["test.js"].source.text.toString()).toBe(`const bar = "foo"
 
 console.log(bar);
 `);
+    done();
   });
 
-  it("nests", () => {
+  it("nests", async (done) => {
     const source = new Document({
       text: `a
 :remove-start:
@@ -78,11 +79,12 @@ e
     });
 
     const parseResult = bluehawk.parse(source);
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     expect(files["test.js"].source.text.toString()).toBe(
       `a
 e
 `
     );
+    done();
   });
 });

--- a/src/commands/snippetCommand.test.ts
+++ b/src/commands/snippetCommand.test.ts
@@ -8,7 +8,7 @@ describe("snippet Command", () => {
   bluehawk.registerCommand("snippet", SnippetCommand);
   bluehawk.registerCommand("hide", RemoveCommand);
 
-  it("performs extraction", () => {
+  it("performs extraction", async (done) => {
     const snippet = `describe("some stuff", () => {
   it("foos the bar", () => {
     expect(true).toBeTruthy();
@@ -27,7 +27,7 @@ console.log(bar);
     });
 
     const parseResult = bluehawk.parse(source);
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     expect(Object.keys(files)).toStrictEqual([
       "snippet.test.js",
       "snippet.test.codeblock.foo.js",
@@ -35,9 +35,10 @@ console.log(bar);
     expect(files["snippet.test.codeblock.foo.js"].source.text.toString()).toBe(
       `${snippet}\n`
     );
+    done();
   });
 
-  it("dedents the snippet", () => {
+  it("dedents the snippet", async (done) => {
     const source = new Document({
       text: `const bar = "foo"
     // :snippet-start: foo
@@ -51,16 +52,17 @@ console.log(bar);
     });
 
     const parseResult = bluehawk.parse(source);
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     expect(files["snippet.test.codeblock.foo.js"].source.text.toString()).toBe(
       `  abc
    def
 ghi
 `
     );
+    done();
   });
 
-  it("dedents a realistic snippet", () => {
+  it("dedents a realistic snippet", async (done) => {
     const source = new Document({
       text: `        // :snippet-start: delete-collection
         let realm = try! Realm()
@@ -78,7 +80,7 @@ ghi
     });
 
     const parseResult = bluehawk.parse(source);
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     expect(
       files[
         "snippet.test.codeblock.delete-collection.swift"
@@ -94,9 +96,10 @@ try! realm.write {
 }
 `
     );
+    done();
   });
 
-  it("handles empty snippets", () => {
+  it("handles empty snippets", async (done) => {
     const source = new Document({
       text: `const bar = "foo"
     // :snippet-start: foo
@@ -107,13 +110,14 @@ try! realm.write {
     });
 
     const parseResult = bluehawk.parse(source);
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     expect(files["snippet.test.codeblock.foo.js"].source.text.toString()).toBe(
       ""
     );
+    done();
   });
 
-  it("handles adjusted offsets", () => {
+  it("handles adjusted offsets", async (done) => {
     const source = new Document({
       text: `some text
 // :snippet-start: foo
@@ -127,9 +131,10 @@ hide this
     });
 
     const parseResult = bluehawk.parse(source);
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     expect(files["snippet.test.codeblock.foo.js"].source.text.toString()).toBe(
       ""
     );
+    done();
   });
 });

--- a/src/commands/stateCommand.test.ts
+++ b/src/commands/stateCommand.test.ts
@@ -11,7 +11,7 @@ describe("stateCommand", () => {
   bluehawk.registerCommand("remove", RemoveCommand);
   bluehawk.registerCommand("snippet", SnippetCommand);
 
-  it("processes nested commands", () => {
+  it("processes nested commands", async (done) => {
     const multipleInput = new Document({
       text: `
 // :state-start: begin
@@ -45,7 +45,7 @@ end
 `;
     const parseResult = bluehawk.parse(multipleInput);
     expect(parseResult.source.path).toBe("stateCommand.test.js");
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     // wait what? Two snippets?
     // It's because the snippet lives outside of the states
     // There would only be one snippet publish if it was nested
@@ -61,5 +61,6 @@ end
     expect(
       files["stateCommand.test.js#state.final"].source.text.toString()
     ).toBe(multipleFinal);
+    done();
   });
 });

--- a/src/commands/uncommentCommand.test.ts
+++ b/src/commands/uncommentCommand.test.ts
@@ -8,7 +8,7 @@ describe("uncomment command", () => {
   bluehawk.registerCommand("uncomment", UncommentCommand);
   bluehawk.registerCommand("remove", RemoveCommand);
 
-  it("uncomments", () => {
+  it("uncomments", async (done) => {
     const source = new Document({
       text: `// :uncomment-start:
 //comment
@@ -21,16 +21,17 @@ no comment
     });
 
     const parseResult = bluehawk.parse(source);
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     expect(files["uncomment.test.js"].source.text.toString()).toBe(
       `comment
 no comment
 // double comment
 `
     );
+    done();
   });
 
-  it("handles one space after comments", () => {
+  it("handles one space after comments", async (done) => {
     const source = new Document({
       text: `// :uncomment-start:
 // comment
@@ -43,16 +44,17 @@ no comment
     });
 
     const parseResult = bluehawk.parse(source);
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     expect(files["uncomment.test.js"].source.text.toString()).toBe(
       `comment
 no comment
 // double comment
 `
     );
+    done();
   });
 
-  it("nests", () => {
+  it("nests", async (done) => {
     const source = new Document({
       text: `// :uncomment-start:
 // comment
@@ -67,16 +69,17 @@ no comment
     });
 
     const parseResult = bluehawk.parse(source);
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     expect(files["uncomment.test.js"].source.text.toString()).toBe(
       `comment
 no comment
 // double comment
 `
     );
+    done();
   });
 
-  it("pairs with remove", () => {
+  it("pairs with remove", async (done) => {
     const source = new Document({
       text: `// :uncomment-start:
 // comment
@@ -92,11 +95,12 @@ no comment
     });
 
     const parseResult = bluehawk.parse(source);
-    const files = bluehawk.process(parseResult);
+    const files = await bluehawk.process(parseResult);
     expect(files["uncomment.test.js"].source.text.toString()).toBe(
       `comment
 // double comment
 `
     );
+    done();
   });
 });

--- a/src/io/parseSource.ts
+++ b/src/io/parseSource.ts
@@ -106,7 +106,9 @@ export async function main(
 
   onFileProcessed.forEach((listener) => bluehawk.subscribe(listener));
 
-  (await fileEntry(source, ignores)).forEach((file) => {
+  const files = await fileEntry(source, ignores);
+
+  const promises = files.map(async (file) => {
     try {
       if (isBinary(file)) {
         onBinaryFile && onBinaryFile(file);
@@ -124,7 +126,7 @@ export async function main(
         );
         return;
       }
-      bluehawk.process(result);
+      await bluehawk.process(result);
     } catch (e) {
       console.error(`Encountered the following error while processing ${file}:
 ${e.stack}
@@ -132,4 +134,5 @@ ${e.stack}
 This is probably a bug in Bluehawk. Please send this stack trace (and the contents of ${file}, if possible) to the Bluehawk development team at https://github.com/mongodb-university/Bluehawk/issues/new`);
     }
   });
+  await Promise.all(promises);
 }

--- a/src/processor/Processor.test.ts
+++ b/src/processor/Processor.test.ts
@@ -1,0 +1,64 @@
+import { Bluehawk } from "../bluehawk";
+import { removeMetaRange } from "../commands/removeMetaRange";
+import { Document } from "../Document";
+
+describe("processor", () => {
+  const bluehawk = new Bluehawk();
+
+  bluehawk.registerCommand("append-message-after-delay", {
+    rules: [],
+    process: (request): Promise<void> => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          const { command, parseResult } = request;
+          const { source } = parseResult;
+          removeMetaRange(source.text, command);
+          source.text.appendLeft(
+            command.range.end.offset,
+            "async command executed"
+          );
+          resolve();
+        }, 50);
+      });
+    },
+  });
+
+  it("ignores unknown commands", async (done) => {
+    // NOTE: This is not necessarily the desired behavior, but it is the current
+    // behavior.
+    const source = new Document({
+      text: `:unknown-command:
+`,
+      language: "javascript",
+      path: "test.js",
+    });
+
+    const parseResult = bluehawk.parse(source);
+    expect(parseResult.commandNodes[0].commandName).toBe("unknown-command");
+    const files = await bluehawk.process(parseResult);
+    expect(files["test.js"].source.text.toString()).toBe(`:unknown-command:
+`);
+    done();
+  });
+
+  it("supports async commands", async (done) => {
+    const source = new Document({
+      text: `// :append-message-after-delay-start:
+a
+b
+c
+// :append-message-after-delay-end:
+`,
+      language: "javascript",
+      path: "test.js",
+    });
+
+    const parseResult = bluehawk.parse(source);
+    const files = await bluehawk.process(parseResult);
+    expect(files["test.js"].source.text.toString()).toBe(`a
+b
+c
+async command executed`);
+    done();
+  });
+});


### PR DESCRIPTION
- Adds support for async commands and listeners
- Per Nathan's idea of eventually having commands or listeners that could do something with HTTP
- Minor refactor to processor required. Most changes are to update tests to use async interface.