### PR TITLE
Fix interop of Replace + snippet dedent

### DIFF
--- a/src/commands/SnippetCommand.ts
+++ b/src/commands/SnippetCommand.ts
@@ -15,7 +15,10 @@ function dedentRange(
   }
 
   // Get inner content and split by line break
-  const content = s.slice(contentRange.start.offset, contentRange.end.offset);
+  const content = s.original.substring(
+    contentRange.start.offset,
+    contentRange.end.offset
+  );
   const lines = content.split(/\r\n|\r|\n/);
   // Remove trailing newline
   lines.pop();


### PR DESCRIPTION
- Dedent would remove at the wrong index after a replace command in the snippets
- This uses the original string to get the correct indexes