### PR TITLE
Update visitor for updated Chevrotain visitor validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2005,9 +2005,9 @@
       "dev": true
     },
     "chevrotain": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.0.2.tgz",
-      "integrity": "sha512-fIio7ZZCTczF0a+hnM171hM+Di2LanUc7nC0fL3qb1FKfZ2xfXZF3BmwHAkfvXlxpNah3LpOtNtUms2JzvR9pg==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-7.1.0.tgz",
+      "integrity": "sha512-msTqYIGb+8z4UpNxliBlowlfFJtBQjTSdnOWgMD/llcE5cQHDbFMjHGdCMJSsPG/Op89c6/ERCmYku4UHDhHVA==",
       "requires": {
         "regexp-to-ast": "0.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "ajv": "^7.0.3",
-    "chevrotain": "^7.0.2",
+    "chevrotain": "^7.1.0",
     "ignore": "^5.1.8",
     "istextorbinary": "^5.12.0",
     "magic-string": "^0.25.7",


### PR DESCRIPTION
- Upgrade Chevrotain
- Chevrotain visitor validation required corresponding grammar rules
  for all methods.
- Despite allowing $ names locally as helpers on chevrotain 7.0, it seems this triggered the
  error in 7.1:

Error: Errors Detected in CST Visitor :
Redundant visitor method: <$visit> on CstVisitor CST Visitor
There is no Grammar Rule corresponding to this method's name.
at CstVisitor.validateVisitor (/usr/local/lib/node_modules/bluehawk/node_modules/chevrotain/lib/src/parse/cst/cst_visitor.js:49:23)
at new CstVisitor (/usr/local/lib/node_modules/bluehawk/build/bluehawk/parser/visitor/makeCstVisitor.js:109:19)
at Object.makeCstVisitor (/usr/local/lib/node_modules/bluehawk/build/bluehawk/parser/visitor/makeCstVisitor.js:102:12)
at Bluehawk.parse (/usr/local/lib/node_modules/bluehawk/build/bluehawk/bluehawk.js:86:80)
at Object. (/usr/local/lib/node_modules/bluehawk/build/cli/parseSource.js:198:55)
at step (/usr/local/lib/node_modules/bluehawk/build/cli/parseSource.js:52:23)
at Object.next (/usr/local/lib/node_modules/bluehawk/build/cli/parseSource.js:33:53)
at /usr/local/lib/node_modules/bluehawk/build/cli/parseSource.js:27:71
at new Promise ()
at __awaiter (/usr/local/lib/node_modules/bluehawk/build/cli/parseSource.js:23:12)

- Solution: externalize the helper method from the class
