### PR TITLE
Detect mismatched command names earlier in parser

### DIFF
--- a/src/bluehawk/parser/extractCommandNamesFromTokens.ts
+++ b/src/bluehawk/parser/extractCommandNamesFromTokens.ts
@@ -8,11 +8,11 @@ export function extractCommandNamesFromTokens(
 ): [string, string] {
   const startPatternResult = COMMAND_START_PATTERN.exec(startToken.image);
   assert(startPatternResult !== null);
+  assert(startPatternResult.length > 1);
   const commandName = startPatternResult[1];
-  assert(commandName !== null);
   const endPatternResult = COMMAND_END_PATTERN.exec(endToken.image);
   assert(endPatternResult !== null);
+  assert(endPatternResult.length > 1);
   const endCommandName = endPatternResult[1];
-  assert(endCommandName !== null);
   return [commandName, endCommandName];
 }

--- a/src/bluehawk/parser/extractCommandNamesFromTokens.ts
+++ b/src/bluehawk/parser/extractCommandNamesFromTokens.ts
@@ -1,0 +1,18 @@
+import { strict as assert } from "assert";
+import { IToken } from "chevrotain";
+import { COMMAND_START_PATTERN, COMMAND_END_PATTERN } from "./lexer/tokens";
+
+export function extractCommandNamesFromTokens(
+  startToken: IToken,
+  endToken: IToken
+): [string, string] {
+  const startPatternResult = COMMAND_START_PATTERN.exec(startToken.image);
+  assert(startPatternResult !== null);
+  const commandName = startPatternResult[1];
+  assert(commandName !== null);
+  const endPatternResult = COMMAND_END_PATTERN.exec(endToken.image);
+  assert(endPatternResult !== null);
+  const endCommandName = endPatternResult[1];
+  assert(endCommandName !== null);
+  return [commandName, endCommandName];
+}

--- a/src/bluehawk/parser/locationFromToken.ts
+++ b/src/bluehawk/parser/locationFromToken.ts
@@ -1,0 +1,45 @@
+import { strict as assert } from "assert";
+import { IToken } from "chevrotain";
+import { Location } from "../Location";
+
+export function locationFromToken(token: IToken): Location {
+  return {
+    line: token.startLine ?? -1,
+    column: token.startColumn ?? -1,
+    offset: token.startOffset ?? -1,
+  };
+}
+
+export function locationAfterToken(token: IToken, fullText: string): Location {
+  const location: Location = {
+    line: token.endLine ?? -1,
+    column: token.endColumn ?? -1,
+    offset: token.endOffset ?? -1,
+  };
+  // Ensure the line/column are correctly rolled over if the character is
+  // actually a newline
+  const index = location.offset;
+  assert(index !== undefined);
+  if (/\r|\n/.test(fullText[index])) {
+    location.column = 1;
+    location.line += 1;
+  }
+  return location;
+}
+
+export function nextLineAfterToken(token: IToken, fullText: string): Location {
+  assert(token.endOffset !== undefined);
+  assert(token.endLine !== undefined);
+  const re = /.*(\r\n|\r|\n)/y;
+  re.lastIndex = token.endOffset;
+  const match = re.exec(fullText);
+  if (!match) {
+    // This is a weird case. Must be at EOF.
+    return locationAfterToken(token, fullText);
+  }
+  return {
+    column: 1,
+    line: token.endLine + 1,
+    offset: token.endOffset + match[0].length,
+  };
+}

--- a/src/bluehawk/parser/visitor/visitor.test.ts
+++ b/src/bluehawk/parser/visitor/visitor.test.ts
@@ -75,7 +75,7 @@ annotated text
     expect(result.commandNodes[2].commandName).toBe("C-command");
   });
 
-  it("detects mismatched command names", () => {
+  it("detects mismatched non-nested command names", () => {
     const tokens = lexer.tokenize(`
 :this-is-a-command-start:
 :this-is-a-different-command-end:
@@ -652,5 +652,19 @@ c2345678 :a-start:
     expect(result.commandNodes[0].contentRange.end.offset).toBe(
       lines[0].length + lines[1].length + lines[2].length + lines[3].length
     );
+  });
+
+  it("detects mismatched closing tags", () => {
+    const input = `:a-start:
+:b-start:
+b-end: // TYPO!
+:a-end:
+`;
+    const { errors } = parser.parse(input);
+    expect(errors[0].message).toBe("Unexpected ':a-end:' closing ':b-start:'");
+    expect(errors[1].message).toBe(
+      "4:8(43) blockCommand: After Newline, expected CommandEnd but found EOF"
+    );
+    expect(errors.length).toBe(2);
   });
 });


### PR DESCRIPTION
- In the case of nested commands, a mismatched command end name could result in a different parser error when the parser encounters EOF, because the mismatched end name closes the inner but the outer never gets closed. This means the visitor can't report the error accurately because it never gets past the parser stage for the visitor to see.
- Solution is to add a private channel of Bluehawk errors in the parser that can detect things like this.


For example:
```cs
// :code-block-start: transaction
// :replace-start: {
//  "terms": {
//   "WritePerson": "Person",
//   "WriteDog" : "Dog" }
// }
realm.Write(() =>
{
    // Create someone to take care of ssome dogs.
    var ali = new WritePerson { Id = 1, Name = "Ali" };
    realm.Add(ali);
    // Find dogs younger than 2.
    var puppies = realm.All<WriteDog>().Where(dog => dog.Age < 2);
    // Loop through one by one to update.
    foreach (var puppy in puppies)
    {
        // Give all the puppies to Ali.
        puppy.Owner = ali;
    }
});
// replace-end:
// :code-block-end:
```
Note typo in replace-end. Error SHOULD be like: at line 40, found "code-block-end" but expected "replace-end". However the parser is currently not caring about the actual command name, so it was happy to accept "code-block-end" as the closer of the "replace-start", leaving the first "code-block-start" unclosed until the end of the file. This results in: "at line 242 col 2: 242:2(7232) blockCommand: After Newline, expected CommandEnd but found EOF"