### PR TITLE
`Remove` as line command & line command distinction refactor

### DIFF
--- a/src/bluehawk/bluehawk.test.ts
+++ b/src/bluehawk/bluehawk.test.ts
@@ -1,15 +1,24 @@
-import { hasId, idIsUnique } from "./processor/validator";
+import { idIsUnique } from "./processor/validator";
 import { Bluehawk } from "./bluehawk";
 import { Document } from "./Document";
+import {
+  IdRequiredAttributes,
+  IdRequiredAttributesSchema,
+  makeBlockCommand,
+} from "./commands";
 
 describe("bluehawk", () => {
   const bluehawk = new Bluehawk();
-  bluehawk.registerCommand("code-block", {
-    process: () => {
-      return;
-    },
-    rules: [idIsUnique, hasId],
-  });
+  bluehawk.registerCommand(
+    "code-block",
+    makeBlockCommand<IdRequiredAttributes>({
+      attributesSchema: IdRequiredAttributesSchema,
+      process(request) {
+        return;
+      },
+      rules: [idIsUnique],
+    })
+  );
 
   it("handles lexing, parsing, visiting, and validating", () => {
     const input = new Document({
@@ -112,7 +121,7 @@ describe("bluehawk", () => {
         line: 3,
         offset: 25,
       },
-      message: "missing ID for command: 'code-block'",
+      message: "attribute list for 'code-block' command should be object",
     });
   });
 });

--- a/src/bluehawk/bluehawk.ts
+++ b/src/bluehawk/bluehawk.ts
@@ -17,7 +17,10 @@ import { isBinary } from "istextorbinary";
 export class Bluehawk {
   // Register the given command on the processor and validator. This enables
   // support for the command under the given name.
-  registerCommand(name: string, command: AnyCommand): void {
+  registerCommand<Command extends AnyCommand>(
+    name: string,
+    command: Command
+  ): void {
     this.processor.registerCommand(name, command);
   }
 

--- a/src/bluehawk/commands/Command.ts
+++ b/src/bluehawk/commands/Command.ts
@@ -19,7 +19,7 @@ interface Command {
 export interface AnyCommand extends Command {
   supportsBlockMode: boolean;
   supportsLineMode: boolean;
-  process: (request: ProcessRequest<AnyCommandNode>) => void | Promise<void>;
+  process: (request: ProcessRequest) => void | Promise<void>;
 }
 
 // Create a block command implementation. AttributesType is a type that

--- a/src/bluehawk/commands/Command.ts
+++ b/src/bluehawk/commands/Command.ts
@@ -14,27 +14,42 @@ export interface AnyCommand {
 
   // Validator rules to determine if the command meets requirements before
   // processing is possible
-  rules: Rule[];
+  rules?: Rule[];
 }
 
 // A command can operate on a line or block.
 export interface Command<AttributesType = unknown> extends AnyCommand {
-  attributesSchema?: JSONSchemaType<AttributesType>;
+  // Attributes schema applies to the block command version.
+  attributesSchema: JSONSchemaType<AttributesType>;
 
   // The implementation of the command
   process: (request: ProcessRequest) => void | Promise<void>;
 }
 
 export interface BlockCommand<AttributesType = unknown> extends AnyCommand {
-  attributesSchema?: JSONSchemaType<AttributesType>;
+  attributesSchema: JSONSchemaType<AttributesType>;
 
   // The implementation of the command
   process: (request: ProcessRequest<BlockCommandNode>) => void | Promise<void>;
 }
 
-export interface LineCommand<AttributesType = unknown> extends AnyCommand {
-  attributesSchema?: JSONSchemaType<AttributesType>;
-
+export interface LineCommand extends AnyCommand {
   // The implementation of the command
   process: (request: ProcessRequest<LineCommandNode>) => void | Promise<void>;
 }
+
+// Helper for commands that require IDs in the attributes only
+export type IdRequiredAttributes = { id: string };
+export const IdRequiredAttributesSchema: JSONSchemaType<IdRequiredAttributes> = {
+  type: "object",
+  required: ["id"],
+  properties: {
+    id: { type: "string" },
+  },
+};
+
+export type NoAttributes = null;
+export const NoAttributesSchema: JSONSchemaType<NoAttributes> = {
+  type: "null",
+  nullable: true,
+};

--- a/src/bluehawk/commands/Command.ts
+++ b/src/bluehawk/commands/Command.ts
@@ -1,6 +1,7 @@
 import { Rule } from "../processor/validator";
 import { ProcessRequest } from "../processor/Processor";
 import { AnySchema, JSONSchemaType } from "ajv";
+import { BlockCommandNode, LineCommandNode } from "../parser";
 
 // The implementation that actually carries out the command.
 
@@ -14,11 +15,26 @@ export interface AnyCommand {
   // Validator rules to determine if the command meets requirements before
   // processing is possible
   rules: Rule[];
+}
 
-  // Implementation of the command
+// A command can operate on a line or block.
+export interface Command<AttributesType = unknown> extends AnyCommand {
+  attributesSchema?: JSONSchemaType<AttributesType>;
+
+  // The implementation of the command
   process: (request: ProcessRequest) => void | Promise<void>;
 }
 
-export interface Command<AttributesType = unknown> extends AnyCommand {
+export interface BlockCommand<AttributesType = unknown> extends AnyCommand {
   attributesSchema?: JSONSchemaType<AttributesType>;
+
+  // The implementation of the command
+  process: (request: ProcessRequest<BlockCommandNode>) => void | Promise<void>;
+}
+
+export interface LineCommand<AttributesType = unknown> extends AnyCommand {
+  attributesSchema?: JSONSchemaType<AttributesType>;
+
+  // The implementation of the command
+  process: (request: ProcessRequest<LineCommandNode>) => void | Promise<void>;
 }

--- a/src/bluehawk/commands/RemoveCommand.ts
+++ b/src/bluehawk/commands/RemoveCommand.ts
@@ -1,9 +1,8 @@
-import { ProcessRequest } from "../processor/Processor";
-import { Command } from "./Command";
+import { Command, NoAttributes, NoAttributesSchema } from "./Command";
 
-export const RemoveCommand: Command = {
-  rules: [], // TODO: Accepts no attributes
-  process: ({ commandNode, parseResult }: ProcessRequest): void => {
+export const RemoveCommand: Command<NoAttributes> = {
+  attributesSchema: NoAttributesSchema,
+  process({ commandNode, parseResult }) {
     const { lineRange } = commandNode;
     parseResult.source.text.remove(
       lineRange.start.offset,

--- a/src/bluehawk/commands/RemoveCommand.ts
+++ b/src/bluehawk/commands/RemoveCommand.ts
@@ -1,6 +1,10 @@
-import { Command, NoAttributes, NoAttributesSchema } from "./Command";
+import {
+  makeBlockOrLineCommand,
+  NoAttributes,
+  NoAttributesSchema,
+} from "./Command";
 
-export const RemoveCommand: Command<NoAttributes> = {
+export const RemoveCommand = makeBlockOrLineCommand<NoAttributes>({
   attributesSchema: NoAttributesSchema,
   process({ commandNode, parseResult }) {
     const { lineRange } = commandNode;
@@ -9,4 +13,4 @@ export const RemoveCommand: Command<NoAttributes> = {
       lineRange.end.offset
     );
   },
-};
+});

--- a/src/bluehawk/commands/RemoveCommand.ts
+++ b/src/bluehawk/commands/RemoveCommand.ts
@@ -3,8 +3,8 @@ import { Command } from "./Command";
 
 export const RemoveCommand: Command = {
   rules: [], // TODO: Accepts no attributes
-  process: ({ command, parseResult }: ProcessRequest): void => {
-    const { lineRange } = command;
+  process: ({ commandNode, parseResult }: ProcessRequest): void => {
+    const { lineRange } = commandNode;
     parseResult.source.text.remove(
       lineRange.start.offset,
       lineRange.end.offset

--- a/src/bluehawk/commands/ReplaceCommand.ts
+++ b/src/bluehawk/commands/ReplaceCommand.ts
@@ -25,8 +25,8 @@ export const ReplaceCommand: Command<ReplaceCommandAttributes> = {
 
   rules: [],
 
-  process: ({ command, parseResult }: ProcessRequest): void => {
-    const attributes = command.attributes as
+  process: ({ commandNode, parseResult }: ProcessRequest): void => {
+    const attributes = commandNode.attributes as
       | ReplaceCommandAttributes
       | undefined;
     if (attributes === undefined) {
@@ -38,9 +38,9 @@ export const ReplaceCommand: Command<ReplaceCommandAttributes> = {
     const { text } = source;
 
     // Strip tags
-    removeMetaRange(text, command);
+    removeMetaRange(text, commandNode);
 
-    const { contentRange } = command;
+    const { contentRange } = commandNode;
     if (contentRange == undefined) {
       // TODO: error
       return;

--- a/src/bluehawk/commands/ReplaceCommand.ts
+++ b/src/bluehawk/commands/ReplaceCommand.ts
@@ -23,8 +23,6 @@ export const ReplaceCommand: Command<ReplaceCommandAttributes> = {
     },
   },
 
-  rules: [],
-
   process: ({ commandNode, parseResult }: ProcessRequest): void => {
     const attributes = commandNode.attributes as
       | ReplaceCommandAttributes

--- a/src/bluehawk/commands/ReplaceCommand.ts
+++ b/src/bluehawk/commands/ReplaceCommand.ts
@@ -1,5 +1,4 @@
-import { ProcessRequest } from "../processor/Processor";
-import { Command } from "./Command";
+import { makeBlockCommand } from "./Command";
 import { removeMetaRange } from "./removeMetaRange";
 
 type ReplaceCommandAttributes = {
@@ -9,7 +8,7 @@ type ReplaceCommandAttributes = {
   };
 };
 
-export const ReplaceCommand: Command<ReplaceCommandAttributes> = {
+export const ReplaceCommand = makeBlockCommand<ReplaceCommandAttributes>({
   attributesSchema: {
     type: "object",
     required: ["terms"],
@@ -23,15 +22,8 @@ export const ReplaceCommand: Command<ReplaceCommandAttributes> = {
     },
   },
 
-  process: ({ commandNode, parseResult }: ProcessRequest): void => {
-    const attributes = commandNode.attributes as
-      | ReplaceCommandAttributes
-      | undefined;
-    if (attributes === undefined) {
-      // TODO: error (though this can't happen if the validator was used
-      return;
-    }
-
+  process({ commandNode, parseResult }) {
+    const attributes = commandNode.attributes as ReplaceCommandAttributes;
     const { source } = parseResult;
     const { text } = source;
 
@@ -64,4 +56,4 @@ export const ReplaceCommand: Command<ReplaceCommandAttributes> = {
       }
     });
   },
-};
+});

--- a/src/bluehawk/commands/SnippetCommand.ts
+++ b/src/bluehawk/commands/SnippetCommand.ts
@@ -4,7 +4,7 @@ import { BlockCommandNode } from "../parser/CommandNode";
 import { ProcessRequest } from "../processor/Processor";
 import { idIsUnique } from "../processor/validator";
 import {
-  BlockCommand,
+  makeBlockCommand,
   IdRequiredAttributes,
   IdRequiredAttributesSchema,
 } from "./Command";
@@ -59,7 +59,7 @@ function dedentRange(
   return s;
 }
 
-export const SnippetCommand: BlockCommand<IdRequiredAttributes> = {
+export const SnippetCommand = makeBlockCommand<IdRequiredAttributes>({
   attributesSchema: IdRequiredAttributesSchema,
   rules: [idIsUnique],
   process: (request: ProcessRequest<BlockCommandNode>): void => {
@@ -100,4 +100,4 @@ export const SnippetCommand: BlockCommand<IdRequiredAttributes> = {
       },
     });
   },
-};
+});

--- a/src/bluehawk/commands/SnippetCommand.ts
+++ b/src/bluehawk/commands/SnippetCommand.ts
@@ -2,9 +2,13 @@ import MagicString from "magic-string";
 import { Document } from "../Document";
 import { BlockCommandNode } from "../parser/CommandNode";
 import { ProcessRequest } from "../processor/Processor";
-import { BlockCommand } from "./Command";
+import { idIsUnique } from "../processor/validator";
+import {
+  BlockCommand,
+  IdRequiredAttributes,
+  IdRequiredAttributesSchema,
+} from "./Command";
 import { removeMetaRange } from "./removeMetaRange";
-import { hasId, idIsUnique } from "../processor/validator";
 
 function dedentRange(
   s: MagicString,
@@ -55,8 +59,9 @@ function dedentRange(
   return s;
 }
 
-export const SnippetCommand: BlockCommand = {
-  rules: [hasId, idIsUnique],
+export const SnippetCommand: BlockCommand<IdRequiredAttributes> = {
+  attributesSchema: IdRequiredAttributesSchema,
+  rules: [idIsUnique],
   process: (request: ProcessRequest<BlockCommandNode>): void => {
     const { commandNode, parseResult, fork } = request;
     const { source } = parseResult;

--- a/src/bluehawk/commands/SnippetCommand.ts
+++ b/src/bluehawk/commands/SnippetCommand.ts
@@ -1,14 +1,14 @@
 import MagicString from "magic-string";
 import { Document } from "../Document";
-import { CommandNode } from "../parser/CommandNode";
+import { BlockCommandNode } from "../parser/CommandNode";
 import { ProcessRequest } from "../processor/Processor";
-import { Command } from "./Command";
+import { BlockCommand } from "./Command";
 import { removeMetaRange } from "./removeMetaRange";
 import { hasId, idIsUnique } from "../processor/validator";
 
 function dedentRange(
   s: MagicString,
-  { contentRange }: CommandNode
+  { contentRange }: BlockCommandNode
 ): MagicString {
   if (contentRange === undefined) {
     return s;
@@ -55,12 +55,12 @@ function dedentRange(
   return s;
 }
 
-export const SnippetCommand: Command = {
+export const SnippetCommand: BlockCommand = {
   rules: [hasId, idIsUnique],
-  process: (request: ProcessRequest): void => {
-    const { command, parseResult, fork } = request;
+  process: (request: ProcessRequest<BlockCommandNode>): void => {
+    const { commandNode, parseResult, fork } = request;
     const { source } = parseResult;
-    const { contentRange } = command;
+    const { contentRange } = commandNode;
 
     if (contentRange === undefined) {
       // TODO: diagnostics
@@ -68,7 +68,7 @@ export const SnippetCommand: Command = {
     }
 
     // Strip tags
-    removeMetaRange(source.text, command);
+    removeMetaRange(source.text, commandNode);
 
     // Copy text to new working copy
     const clonedSnippet = source.text.snip(
@@ -77,21 +77,21 @@ export const SnippetCommand: Command = {
     );
 
     // Dedent
-    dedentRange(clonedSnippet, command);
+    dedentRange(clonedSnippet, commandNode);
 
     // Fork subset code block to another file
     fork({
       parseResult: {
-        commandNodes: command.children ?? [],
+        commandNodes: commandNode.children ?? [],
         errors: [],
         source: new Document({
           ...source,
-          path: source.pathWithInfix(`codeblock.${command.id}`),
+          path: source.pathWithInfix(`codeblock.${commandNode.id}`),
           text: clonedSnippet,
         }),
       },
       newAttributes: {
-        snippet: command.id,
+        snippet: commandNode.id,
       },
     });
   },

--- a/src/bluehawk/commands/StateCommand.ts
+++ b/src/bluehawk/commands/StateCommand.ts
@@ -1,11 +1,13 @@
-import { ProcessRequest } from "../processor/Processor";
-import { Command } from "./Command";
+import {
+  BlockCommand,
+  IdRequiredAttributes,
+  IdRequiredAttributesSchema,
+} from "./Command";
 import { removeMetaRange } from "./removeMetaRange";
-import { hasId } from "../processor/validator";
 
-export const StateCommand: Command = {
-  rules: [hasId],
-  process: (request: ProcessRequest): void => {
+export const StateCommand: BlockCommand<IdRequiredAttributes> = {
+  attributesSchema: IdRequiredAttributesSchema,
+  process(request) {
     const { commandNode, fork, parseResult } = request;
     const { source } = parseResult;
 

--- a/src/bluehawk/commands/StateCommand.ts
+++ b/src/bluehawk/commands/StateCommand.ts
@@ -1,11 +1,11 @@
 import {
-  BlockCommand,
+  makeBlockCommand,
   IdRequiredAttributes,
   IdRequiredAttributesSchema,
 } from "./Command";
 import { removeMetaRange } from "./removeMetaRange";
 
-export const StateCommand: BlockCommand<IdRequiredAttributes> = {
+export const StateCommand = makeBlockCommand<IdRequiredAttributes>({
   attributesSchema: IdRequiredAttributesSchema,
   process(request) {
     const { commandNode, fork, parseResult } = request;
@@ -39,4 +39,4 @@ export const StateCommand: BlockCommand<IdRequiredAttributes> = {
       source.text.remove(contentRange.start.offset, contentRange.end.offset);
     }
   },
-};
+});

--- a/src/bluehawk/commands/StateCommand.ts
+++ b/src/bluehawk/commands/StateCommand.ts
@@ -6,11 +6,11 @@ import { hasId } from "../processor/validator";
 export const StateCommand: Command = {
   rules: [hasId],
   process: (request: ProcessRequest): void => {
-    const { command, fork, parseResult } = request;
+    const { commandNode, fork, parseResult } = request;
     const { source } = parseResult;
 
     // Strip tags
-    removeMetaRange(source.text, command);
+    removeMetaRange(source.text, commandNode);
 
     const stateAttribute = source.attributes["state"];
 
@@ -18,18 +18,18 @@ export const StateCommand: Command = {
       // We are not processing in a state file, so start one
       fork({
         parseResult,
-        newModifier: `state.${command.id}`,
+        newModifier: `state.${commandNode.id}`,
         newAttributes: {
           // Set the state attribute for next time StateCommand is invoked on the
           // new file
-          state: command.id,
+          state: commandNode.id,
         },
       });
     }
 
     // Strip all other states
-    if (stateAttribute !== command.id) {
-      const { contentRange } = command;
+    if (stateAttribute !== commandNode.id) {
+      const { contentRange } = commandNode;
       if (contentRange === undefined) {
         // TODO: diagnostics
         return;

--- a/src/bluehawk/commands/UncommentCommand.ts
+++ b/src/bluehawk/commands/UncommentCommand.ts
@@ -1,26 +1,29 @@
 import { strict as assert } from "assert";
 import { IToken } from "chevrotain";
+import { BlockCommandNode, LineCommandNode } from "../parser";
 import { flatten } from "../parser/flatten";
 import { ProcessRequest } from "../processor/Processor";
-import { Command } from "./Command";
+import { BlockCommand } from "./Command";
 import { removeMetaRange } from "./removeMetaRange";
 
-export const UncommentCommand: Command = {
+export const UncommentCommand: BlockCommand = {
   rules: [],
-  process: (request: ProcessRequest): void => {
-    const { command, parseResult } = request;
+  process: (request: ProcessRequest<BlockCommandNode>): void => {
+    const { commandNode, parseResult } = request;
     const { source } = parseResult;
 
     // Strip tags
-    removeMetaRange(source.text, command);
+    removeMetaRange(source.text, commandNode);
 
-    const { contentRange } = command;
+    const { contentRange } = commandNode;
     if (contentRange == undefined) {
       return;
     }
 
     // Get all line comments in the hierarchy
-    const lineComments = flatten(command)
+    const lineComments = flatten(
+      commandNode as BlockCommandNode | LineCommandNode
+    )
       .reduce((acc, cur) => [...acc, ...cur.lineComments], [] as IToken[])
       .sort((a, b) => a.startOffset - b.startOffset);
 

--- a/src/bluehawk/commands/UncommentCommand.ts
+++ b/src/bluehawk/commands/UncommentCommand.ts
@@ -1,14 +1,12 @@
 import { strict as assert } from "assert";
 import { IToken } from "chevrotain";
-import { BlockCommandNode, LineCommandNode } from "../parser";
-import { flatten } from "../parser/flatten";
-import { ProcessRequest } from "../processor/Processor";
-import { BlockCommand } from "./Command";
+import { AnyCommandNode, flatten } from "../parser";
+import { BlockCommand, NoAttributes, NoAttributesSchema } from "./Command";
 import { removeMetaRange } from "./removeMetaRange";
 
-export const UncommentCommand: BlockCommand = {
-  rules: [],
-  process: (request: ProcessRequest<BlockCommandNode>): void => {
+export const UncommentCommand: BlockCommand<NoAttributes> = {
+  attributesSchema: NoAttributesSchema,
+  process(request) {
     const { commandNode, parseResult } = request;
     const { source } = parseResult;
 
@@ -21,9 +19,7 @@ export const UncommentCommand: BlockCommand = {
     }
 
     // Get all line comments in the hierarchy
-    const lineComments = flatten(
-      commandNode as BlockCommandNode | LineCommandNode
-    )
+    const lineComments = flatten(commandNode as AnyCommandNode)
       .reduce((acc, cur) => [...acc, ...cur.lineComments], [] as IToken[])
       .sort((a, b) => a.startOffset - b.startOffset);
 

--- a/src/bluehawk/commands/UncommentCommand.ts
+++ b/src/bluehawk/commands/UncommentCommand.ts
@@ -1,10 +1,10 @@
 import { strict as assert } from "assert";
 import { IToken } from "chevrotain";
 import { AnyCommandNode, flatten } from "../parser";
-import { BlockCommand, NoAttributes, NoAttributesSchema } from "./Command";
+import { makeBlockCommand, NoAttributes, NoAttributesSchema } from "./Command";
 import { removeMetaRange } from "./removeMetaRange";
 
-export const UncommentCommand: BlockCommand<NoAttributes> = {
+export const UncommentCommand = makeBlockCommand<NoAttributes>({
   attributesSchema: NoAttributesSchema,
   process(request) {
     const { commandNode, parseResult } = request;
@@ -36,4 +36,4 @@ export const UncommentCommand: BlockCommand<NoAttributes> = {
         source.text.remove(lineComment.startOffset, lineComment.endOffset + 1);
       });
   },
-};
+});

--- a/src/bluehawk/commands/removeCommand.test.ts
+++ b/src/bluehawk/commands/removeCommand.test.ts
@@ -87,4 +87,23 @@ e
     );
     done();
   });
+
+  it("requires no attributes", () => {
+    const input = `// :remove-start: {
+  "id": "hey"
+}
+// :remove-end:
+`;
+
+    const source = new Document({
+      text: input,
+      language: "javascript",
+      path: "test.js",
+    });
+
+    const parseResult = bluehawk.parse(source);
+    expect(parseResult.errors[0].message).toStrictEqual(
+      "attribute list for 'remove' command should be null"
+    );
+  });
 });

--- a/src/bluehawk/commands/removeCommand.test.ts
+++ b/src/bluehawk/commands/removeCommand.test.ts
@@ -106,4 +106,29 @@ e
       "attribute list for 'remove' command should be null"
     );
   });
+
+  it("works as a line command", async (done) => {
+    const input = `leave this
+this should be removed // :remove:
+and leave this
+this should also be removed // :remove: // do it
+but not this
+`;
+
+    const source = new Document({
+      text: input,
+      language: "javascript",
+      path: "test.js",
+    });
+
+    const parseResult = bluehawk.parse(source);
+    const files = await bluehawk.process(parseResult);
+    expect(files["test.js"].source.text.toString()).toBe(
+      `leave this
+and leave this
+but not this
+`
+    );
+    done();
+  });
 });

--- a/src/bluehawk/commands/replaceCommand.test.ts
+++ b/src/bluehawk/commands/replaceCommand.test.ts
@@ -178,7 +178,7 @@ andremovethisaswell
     });
 
     const parseResult = bluehawk.parse(source);
-    expect(parseResult.errors.length).toBe(0);
+    expect(parseResult.errors).toStrictEqual([]);
     const files = await bluehawk.process(parseResult);
     expect(files["replace.test.js"].source.text.toString())
       .toBe(`leave this alone

--- a/src/bluehawk/getBluehawk.ts
+++ b/src/bluehawk/getBluehawk.ts
@@ -4,11 +4,13 @@ import {
   ReplaceCommand,
   RemoveCommand,
   StateCommand,
-  ProcessRequest,
   UncommentCommand,
 } from ".";
-import { BlockCommand } from "./commands";
-import { BlockCommandNode } from "./parser";
+import {
+  BlockCommand,
+  IdRequiredAttributes,
+  IdRequiredAttributesSchema,
+} from "./commands";
 
 let bluehawk: Bluehawk | undefined = undefined;
 
@@ -29,9 +31,9 @@ export const getBluehawk = async (
     // hide and replace-with now belong to "state"
     bluehawk.registerCommand("state", StateCommand);
 
-    const StateUncommentCommand: BlockCommand = {
-      rules: [...StateCommand.rules],
-      process: (request: ProcessRequest<BlockCommandNode>): void => {
+    const StateUncommentCommand: BlockCommand<IdRequiredAttributes> = {
+      attributesSchema: IdRequiredAttributesSchema,
+      process(request) {
         UncommentCommand.process(request);
         StateCommand.process(request);
       },

--- a/src/bluehawk/getBluehawk.ts
+++ b/src/bluehawk/getBluehawk.ts
@@ -7,6 +7,8 @@ import {
   ProcessRequest,
   UncommentCommand,
 } from ".";
+import { BlockCommand } from "./commands";
+import { BlockCommandNode } from "./parser";
 
 let bluehawk: Bluehawk | undefined = undefined;
 
@@ -27,14 +29,16 @@ export const getBluehawk = async (
     // hide and replace-with now belong to "state"
     bluehawk.registerCommand("state", StateCommand);
 
-    // uncomment the block in the state
-    bluehawk.registerCommand("state-uncomment", {
+    const StateUncommentCommand: BlockCommand = {
       rules: [...StateCommand.rules],
-      process: (request: ProcessRequest): void => {
+      process: (request: ProcessRequest<BlockCommandNode>): void => {
         UncommentCommand.process(request);
         StateCommand.process(request);
       },
-    });
+    };
+
+    // uncomment the block in the state
+    bluehawk.registerCommand("state-uncomment", StateUncommentCommand);
   }
 
   await bluehawk.loadPlugin(pluginPaths);

--- a/src/bluehawk/getBluehawk.ts
+++ b/src/bluehawk/getBluehawk.ts
@@ -7,7 +7,7 @@ import {
   UncommentCommand,
 } from ".";
 import {
-  BlockCommand,
+  makeBlockCommand,
   IdRequiredAttributes,
   IdRequiredAttributesSchema,
 } from "./commands";
@@ -31,13 +31,13 @@ export const getBluehawk = async (
     // hide and replace-with now belong to "state"
     bluehawk.registerCommand("state", StateCommand);
 
-    const StateUncommentCommand: BlockCommand<IdRequiredAttributes> = {
+    const StateUncommentCommand = makeBlockCommand<IdRequiredAttributes>({
       attributesSchema: IdRequiredAttributesSchema,
       process(request) {
         UncommentCommand.process(request);
         StateCommand.process(request);
       },
-    };
+    });
 
     // uncomment the block in the state
     bluehawk.registerCommand("state-uncomment", StateUncommentCommand);

--- a/src/bluehawk/parser/CommandNode.ts
+++ b/src/bluehawk/parser/CommandNode.ts
@@ -36,14 +36,6 @@ export interface CommandNode {
 
   // Attributes come from JSON and their schema depends on the command.
   attributes?: CommandNodeAttributes;
-
-  // Convenience function that returns this instance as a block command or
-  // undefined if it is not a block command.
-  asBlockCommandNode: () => BlockCommandNode | undefined;
-
-  // Convenience function that returns this instance as a line command or
-  // undefined if it is not a block command.
-  asLineCommandNode: () => LineCommandNode | undefined;
 }
 
 export interface LineCommandNode extends CommandNode {
@@ -89,7 +81,7 @@ export class CommandNodeImpl implements CommandNode {
     return this.attributes?.id;
   }
   contentRange?: Range;
-  children?: CommandNode[];
+  children?: CommandNodeImpl[];
   attributes?: CommandNodeAttributes;
   newlines: IToken[];
   lineComments: IToken[];

--- a/src/bluehawk/parser/CommandNode.ts
+++ b/src/bluehawk/parser/CommandNode.ts
@@ -3,7 +3,7 @@ import { IToken } from "chevrotain";
 import { Range } from "../Range";
 
 // The CommandNode represents a command found by the visitor.
-export interface CommandNode {
+interface CommandNode {
   type: "line" | "block";
 
   // The name of the command (without -start or -end).
@@ -54,9 +54,11 @@ export interface LineCommandNode extends CommandNode {
 export interface BlockCommandNode extends CommandNode {
   type: "block";
   contentRange: Range;
-  children: (BlockCommandNode | LineCommandNode)[];
+  children: AnyCommandNode[];
   attributes: CommandNodeAttributes;
 }
+
+export type AnyCommandNode = LineCommandNode | BlockCommandNode;
 
 export type CommandNodeContext =
   | "none"

--- a/src/bluehawk/parser/CommandNode.ts
+++ b/src/bluehawk/parser/CommandNode.ts
@@ -1,7 +1,69 @@
 import { strict as assert } from "assert";
 import { IToken } from "chevrotain";
 import { Range } from "../Range";
-import { CommandNodeContext } from "./visitor/makeCstVisitor";
+
+// The CommandNode represents a command found by the visitor.
+export interface CommandNode {
+  // The name of the command (without -start or -end).
+  commandName: string;
+
+  // For block commands, range from the first character of the command (start)
+  // token to the last character of the command (end) token. For line commands,
+  // range from command token start to end.
+  range: Range;
+
+  // Range from the beginning of the line on which the command (start) token
+  // appears to the end of the line on which the command (end) token appears.
+  lineRange: Range;
+
+  // Potentially useful tokens contained in the node
+  newlines: IToken[];
+  lineComments: IToken[];
+
+  // The comment context the command was found in.
+  inContext: CommandNodeContext;
+
+  // Returns the id found in the attributes list or directly after the block
+  // command.
+  id?: string;
+
+  // Block commands have an inner range that includes the lines between the
+  // attribute list and the end command token.
+  contentRange?: Range;
+
+  // The child command nodes.
+  children?: CommandNode[];
+
+  // Attributes come from JSON and their schema depends on the command.
+  attributes?: CommandNodeAttributes;
+
+  // Convenience function that returns this instance as a block command or
+  // undefined if it is not a block command.
+  asBlockCommandNode: () => BlockCommandNode | undefined;
+
+  // Convenience function that returns this instance as a line command or
+  // undefined if it is not a block command.
+  asLineCommandNode: () => LineCommandNode | undefined;
+}
+
+export interface LineCommandNode extends CommandNode {
+  id: undefined;
+  contentRange: undefined;
+  children: undefined;
+  attributes: undefined;
+}
+
+export interface BlockCommandNode extends CommandNode {
+  contentRange: Range;
+  children: CommandNode[];
+  attributes: CommandNodeAttributes;
+}
+
+export type CommandNodeContext =
+  | "none"
+  | "stringLiteral"
+  | "lineComment"
+  | "blockComment";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type CommandNodeAttributes = { [member: string]: any };
@@ -13,42 +75,27 @@ interface VisitorContext {
   LineComment?: IToken[];
 }
 
-export class CommandNode {
+export class CommandNodeImpl implements CommandNode {
   commandName: string;
   get inContext(): CommandNodeContext {
     return this._context[this._context.length - 1] || "none";
   }
-
   _context = Array<CommandNodeContext>();
-
-  // For block commands, range from the first character of the command (start)
-  // token to the last character of the command (end) token.
   range: Range;
-
-  // Block commands have an inner range that includes the lines between the
-  // attribute list and the end command token.
-  contentRange?: Range;
-
-  // Range from the beginning of the line on which the command (start) token
-  // appears to the end of the line on which the command (end) token appears.
   lineRange: Range;
 
-  // Only available in block commands:
+  // Only available in block commands
   get id(): string | undefined {
     return this.attributes?.id;
   }
+  contentRange?: Range;
   children?: CommandNode[];
-
-  // Attributes come from JSON and their schema depends on the command.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   attributes?: CommandNodeAttributes;
-
-  // Potentially useful tokens contained in the node
   newlines: IToken[];
   lineComments: IToken[];
 
   // Imports potentially useful tokens from a visitor context object.
-  // Only use this in visitors that do not create the CommandNode.
+  // Only use this in visitors that do not create the CommandNodeImpl.
   addTokensFromContext(context: VisitorContext): void {
     this.newlines.push(...(context.Newline ?? []));
     this.lineComments.push(...(context.LineComment ?? []));
@@ -59,9 +106,9 @@ export class CommandNode {
   makeChildBlockCommand(
     commandName: string,
     context: VisitorContext
-  ): CommandNode {
+  ): CommandNodeImpl {
     assert(this.children);
-    const command = new CommandNode(commandName, context, this);
+    const command = new CommandNodeImpl(commandName, context, this);
     command.children = [];
     return command;
   }
@@ -71,20 +118,20 @@ export class CommandNode {
   makeChildLineCommand(
     commandName: string,
     context: VisitorContext
-  ): CommandNode {
+  ): CommandNodeImpl {
     assert(this.children);
-    return new CommandNode(commandName, context, this);
+    return new CommandNodeImpl(commandName, context, this);
   }
 
   withErasedBlockCommand(
     context: VisitorContext,
-    callback: (erasedBlockCommand: CommandNode) => void
+    callback: (erasedBlockCommand: CommandNodeImpl) => void
   ): void {
     assert(this.children);
     // We erase whatever element created the context and add what would have
     // been that element's children to the parent node. This is definitely
     // weird, but only used internally...
-    const node = new CommandNode(
+    const node = new CommandNodeImpl(
       "__this_should_not_be_here___please_file_a_bug__",
       context
     );
@@ -97,8 +144,8 @@ export class CommandNode {
 
   // The root command is the root node of a parsed document and contains all
   // other nodes in the document.
-  static rootCommand(): CommandNode {
-    const command = new CommandNode("__root__", {});
+  static rootCommand(): CommandNodeImpl {
+    const command = new CommandNodeImpl("__root__", {});
     command.children = [];
     return command;
   }
@@ -106,7 +153,7 @@ export class CommandNode {
   private constructor(
     commandName: string,
     context: VisitorContext,
-    parentToAttachTo?: CommandNode
+    parentToAttachTo?: CommandNodeImpl
   ) {
     this.commandName = commandName;
     this.newlines = [];
@@ -143,4 +190,26 @@ export class CommandNode {
       parentToAttachTo.children.push(this);
     }
   }
+
+  asBlockCommandNode = (): BlockCommandNode | undefined => {
+    if (
+      this.contentRange === undefined &&
+      this.children === undefined &&
+      this.attributes === undefined
+    ) {
+      return undefined;
+    }
+    return this as BlockCommandNode;
+  };
+
+  asLineCommandNode = (): LineCommandNode | undefined => {
+    if (
+      this.contentRange === undefined &&
+      this.children === undefined &&
+      this.attributes === undefined
+    ) {
+      return this as LineCommandNode;
+    }
+    return undefined;
+  };
 }

--- a/src/bluehawk/parser/ParseResult.ts
+++ b/src/bluehawk/parser/ParseResult.ts
@@ -1,9 +1,9 @@
-import { CommandNode } from "./CommandNode";
+import { BlockCommandNode, LineCommandNode } from "./CommandNode";
 import { Document } from "../Document";
 import { BluehawkError } from "../BluehawkError";
 
 export interface ParseResult {
   errors: BluehawkError[];
-  commandNodes: CommandNode[];
+  commandNodes: (LineCommandNode | BlockCommandNode)[];
   source: Document;
 }

--- a/src/bluehawk/parser/ParseResult.ts
+++ b/src/bluehawk/parser/ParseResult.ts
@@ -1,9 +1,9 @@
-import { BlockCommandNode, LineCommandNode } from "./CommandNode";
+import { AnyCommandNode } from "./CommandNode";
 import { Document } from "../Document";
 import { BluehawkError } from "../BluehawkError";
 
 export interface ParseResult {
   errors: BluehawkError[];
-  commandNodes: (LineCommandNode | BlockCommandNode)[];
+  commandNodes: AnyCommandNode[];
   source: Document;
 }

--- a/src/bluehawk/parser/index.ts
+++ b/src/bluehawk/parser/index.ts
@@ -1,2 +1,3 @@
 export { ParseResult } from "./ParseResult";
+export { CommandNode, LineCommandNode, BlockCommandNode } from "./CommandNode";
 export * from "./lexer";

--- a/src/bluehawk/parser/index.ts
+++ b/src/bluehawk/parser/index.ts
@@ -1,3 +1,8 @@
 export { ParseResult } from "./ParseResult";
-export { CommandNode, LineCommandNode, BlockCommandNode } from "./CommandNode";
+export {
+  LineCommandNode,
+  BlockCommandNode,
+  AnyCommandNode,
+} from "./CommandNode";
+export * from "./flatten";
 export * from "./lexer";

--- a/src/bluehawk/parser/visitor/makeCstVisitor.ts
+++ b/src/bluehawk/parser/visitor/makeCstVisitor.ts
@@ -8,7 +8,7 @@ import { BluehawkError } from "../../BluehawkError";
 import { Document } from "../../Document";
 import { PushParserPayload } from "../lexer/makePushParserTokens";
 import {
-  BlockCommandNode,
+  AnyCommandNode,
   CommandNodeImpl,
   LineCommandNode,
 } from "../CommandNode";
@@ -23,7 +23,7 @@ import { extractCommandNamesFromTokens } from "../extractCommandNamesFromTokens"
 
 export interface VisitorResult {
   errors: BluehawkError[];
-  commandNodes: (BlockCommandNode | LineCommandNode)[];
+  commandNodes: AnyCommandNode[];
 }
 
 export interface IVisitor {

--- a/src/bluehawk/parser/visitor/makeCstVisitor.ts
+++ b/src/bluehawk/parser/visitor/makeCstVisitor.ts
@@ -7,7 +7,11 @@ import { innerLocationToOuterLocation } from "./innerOffsetToOuterLocation";
 import { BluehawkError } from "../../BluehawkError";
 import { Document } from "../../Document";
 import { PushParserPayload } from "../lexer/makePushParserTokens";
-import { CommandNode, CommandNodeImpl } from "../CommandNode";
+import {
+  BlockCommandNode,
+  CommandNodeImpl,
+  LineCommandNode,
+} from "../CommandNode";
 import {
   locationFromToken,
   locationAfterToken,
@@ -19,7 +23,7 @@ import { extractCommandNamesFromTokens } from "../extractCommandNamesFromTokens"
 
 export interface VisitorResult {
   errors: BluehawkError[];
-  commandNodes: CommandNode[];
+  commandNodes: (BlockCommandNode | LineCommandNode)[];
 }
 
 export interface IVisitor {
@@ -534,7 +538,9 @@ export function makeCstVisitor(
     visitor.visit([node], { errors, parent, source });
     return {
       errors,
-      commandNodes: parent.children ?? [],
+      commandNodes: (parent.children ?? []).map(
+        (child) => child.asBlockCommandNode() ?? (child as LineCommandNode)
+      ),
     };
   };
 

--- a/src/bluehawk/processor/Processor.test.ts
+++ b/src/bluehawk/processor/Processor.test.ts
@@ -1,5 +1,9 @@
 import { Bluehawk } from "../bluehawk";
-import { Command, NoAttributes, NoAttributesSchema } from "../commands/Command";
+import {
+  makeBlockCommand,
+  NoAttributes,
+  NoAttributesSchema,
+} from "../commands/Command";
 import { removeMetaRange } from "../commands/removeMetaRange";
 import { Document } from "../Document";
 import { ParseResult } from "../parser/ParseResult";
@@ -7,7 +11,7 @@ import { ParseResult } from "../parser/ParseResult";
 describe("processor", () => {
   const bluehawk = new Bluehawk();
 
-  const AppendMessageAfterDelayCommand: Command<NoAttributes> = {
+  const AppendMessageAfterDelayCommand = makeBlockCommand<NoAttributes>({
     attributesSchema: NoAttributesSchema,
     process: (request): Promise<void> => {
       return new Promise((resolve) => {
@@ -23,7 +27,7 @@ describe("processor", () => {
         }, 10);
       });
     },
-  };
+  });
 
   bluehawk.registerCommand(
     "append-message-after-delay",

--- a/src/bluehawk/processor/Processor.test.ts
+++ b/src/bluehawk/processor/Processor.test.ts
@@ -1,5 +1,5 @@
 import { Bluehawk } from "../bluehawk";
-import { Command } from "../commands/Command";
+import { Command, NoAttributes, NoAttributesSchema } from "../commands/Command";
 import { removeMetaRange } from "../commands/removeMetaRange";
 import { Document } from "../Document";
 import { ParseResult } from "../parser/ParseResult";
@@ -7,8 +7,8 @@ import { ParseResult } from "../parser/ParseResult";
 describe("processor", () => {
   const bluehawk = new Bluehawk();
 
-  const AppendMessageAfterDelayCommand: Command = {
-    rules: [],
+  const AppendMessageAfterDelayCommand: Command<NoAttributes> = {
+    attributesSchema: NoAttributesSchema,
     process: (request): Promise<void> => {
       return new Promise((resolve) => {
         setTimeout(() => {

--- a/src/bluehawk/processor/Processor.test.ts
+++ b/src/bluehawk/processor/Processor.test.ts
@@ -1,4 +1,5 @@
 import { Bluehawk } from "../bluehawk";
+import { Command } from "../commands/Command";
 import { removeMetaRange } from "../commands/removeMetaRange";
 import { Document } from "../Document";
 import { ParseResult } from "../parser/ParseResult";
@@ -6,23 +7,28 @@ import { ParseResult } from "../parser/ParseResult";
 describe("processor", () => {
   const bluehawk = new Bluehawk();
 
-  bluehawk.registerCommand("append-message-after-delay", {
+  const AppendMessageAfterDelayCommand: Command = {
     rules: [],
     process: (request): Promise<void> => {
       return new Promise((resolve) => {
         setTimeout(() => {
-          const { command, parseResult } = request;
+          const { commandNode, parseResult } = request;
           const { source } = parseResult;
-          removeMetaRange(source.text, command);
+          removeMetaRange(source.text, commandNode);
           source.text.appendLeft(
-            command.range.end.offset,
+            commandNode.range.end.offset,
             "async command executed"
           );
           resolve();
         }, 10);
       });
     },
-  });
+  };
+
+  bluehawk.registerCommand(
+    "append-message-after-delay",
+    AppendMessageAfterDelayCommand
+  );
 
   it("ignores unknown commands", async (done) => {
     // NOTE: This is not necessarily the desired behavior, but it is the current

--- a/src/bluehawk/processor/Processor.ts
+++ b/src/bluehawk/processor/Processor.ts
@@ -1,7 +1,6 @@
-import { ParseResult } from "../parser/ParseResult";
+import { AnyCommandNode, ParseResult } from "../parser";
 import { Document, CommandAttributes } from "../Document";
-import { AnyCommandNode } from "../parser/CommandNode";
-import { AnyCommand, Command } from "../commands/Command";
+import { AnyCommand } from "../commands";
 
 export type BluehawkFiles = { [pathName: string]: ParseResult };
 
@@ -102,8 +101,9 @@ This is probably not a bug in the Bluehawk library itself. Please check with the
       if (command === undefined) {
         return promises;
       }
+      // TODO: validate BlockCommand/LineCommand mode support
       // Commands are not necessarily async
-      const maybePromise = (command as Command).process({
+      const maybePromise = (command as AnyCommand).process({
         fork: (args: ForkArgs) => {
           return this.fork({
             ...args,

--- a/src/bluehawk/processor/Processor.ts
+++ b/src/bluehawk/processor/Processor.ts
@@ -1,13 +1,11 @@
 import { ParseResult } from "../parser/ParseResult";
 import { Document, CommandAttributes } from "../Document";
-import { BlockCommandNode, LineCommandNode } from "../parser/CommandNode";
+import { AnyCommandNode } from "../parser/CommandNode";
 import { AnyCommand, Command } from "../commands/Command";
 
 export type BluehawkFiles = { [pathName: string]: ParseResult };
 
-export interface ProcessRequest<
-  CommandNodeType = BlockCommandNode | LineCommandNode
-> {
+export interface ProcessRequest<CommandNodeType = AnyCommandNode> {
   // Process the given Bluehawk result, optionally under an alternative id, and
   // emit the file.
   fork: (args: ForkArgs) => Promise<void>;
@@ -96,7 +94,7 @@ This is probably not a bug in the Bluehawk library itself. Please check with the
 
   private _process = (
     _processorState: ProcessorState,
-    commandSubset: (LineCommandNode | BlockCommandNode)[],
+    commandSubset: AnyCommandNode[],
     result: ParseResult
   ): Promise<void>[] => {
     return commandSubset.reduce((promises, commandNode): Promise<void>[] => {

--- a/src/bluehawk/processor/makeAttributesConformToJsonSchemaRule.test.ts
+++ b/src/bluehawk/processor/makeAttributesConformToJsonSchemaRule.test.ts
@@ -1,5 +1,9 @@
 import { JSONSchemaType } from "ajv";
-import { CommandNode, CommandNodeAttributes } from "../parser/CommandNode";
+import {
+  CommandNode,
+  CommandNodeImpl,
+  CommandNodeAttributes,
+} from "../parser/CommandNode";
 import { Range } from "../Range";
 import { makeAttributesConformToJsonSchemaRule } from "./makeAttributesConformToJsonSchemaRule";
 import { ValidateCstResult } from "./validator";
@@ -25,7 +29,7 @@ describe("makeAttributesConformToJsonSchemaRule", () => {
   };
 
   const mockCommandNode = (attributes?: CommandNodeAttributes): CommandNode => {
-    const node = CommandNode.rootCommand();
+    const node = CommandNodeImpl.rootCommand();
     node.commandName = "mock";
     node.range = mockRange;
     node.attributes = attributes;

--- a/src/bluehawk/processor/makeAttributesConformToJsonSchemaRule.test.ts
+++ b/src/bluehawk/processor/makeAttributesConformToJsonSchemaRule.test.ts
@@ -1,8 +1,8 @@
 import { JSONSchemaType } from "ajv";
 import {
-  CommandNode,
   CommandNodeImpl,
   CommandNodeAttributes,
+  AnyCommandNode,
 } from "../parser/CommandNode";
 import { Range } from "../Range";
 import { makeAttributesConformToJsonSchemaRule } from "./makeAttributesConformToJsonSchemaRule";
@@ -28,12 +28,14 @@ describe("makeAttributesConformToJsonSchemaRule", () => {
     };
   };
 
-  const mockCommandNode = (attributes?: CommandNodeAttributes): CommandNode => {
+  const mockCommandNode = (
+    attributes?: CommandNodeAttributes
+  ): AnyCommandNode => {
     const node = CommandNodeImpl.rootCommand();
     node.commandName = "mock";
     node.range = mockRange;
     node.attributes = attributes;
-    return node;
+    return node as AnyCommandNode;
   };
 
   type MyType = {

--- a/src/bluehawk/processor/validator.test.ts
+++ b/src/bluehawk/processor/validator.test.ts
@@ -1,16 +1,26 @@
+import { strict as assert } from "assert";
 import { RootParser } from "../parser/RootParser";
 import { makeCstVisitor } from "../parser/visitor/makeCstVisitor";
-import { validateCommands, idIsUnique, hasId } from "./validator";
+import { validateCommands, idIsUnique } from "./validator";
 import { makeBlockCommentTokens } from "../parser/lexer/makeBlockCommentTokens";
 import { makeLineCommentToken } from "../parser/lexer/makeLineCommentToken";
 import { Document } from "../Document";
 import { CommandProcessors } from "./Processor";
-import { makeLineCommand } from "../commands/Command";
+import {
+  IdRequiredAttributes,
+  IdRequiredAttributesSchema,
+  makeBlockCommand,
+  makeBlockOrLineCommand,
+  makeLineCommand,
+  NoAttributes,
+  NoAttributesSchema,
+} from "../commands/Command";
 
 describe("validator", () => {
   const commandProcessors: CommandProcessors = {
-    "code-block": makeLineCommand({
-      rules: [idIsUnique, hasId],
+    "code-block": makeBlockCommand<IdRequiredAttributes>({
+      attributesSchema: IdRequiredAttributesSchema,
+      rules: [idIsUnique],
       process(request) {
         // do nothing
       },
@@ -60,7 +70,7 @@ the quick brown fox jumped
     const errors = validateCommands(result.commandNodes, commandProcessors);
     expect(errors.length).toBe(1);
     expect(errors[0].message).toStrictEqual(
-      "missing ID for command: 'code-block'"
+      "attribute list for 'code-block' command should be object"
     );
     expect(errors[0].location).toStrictEqual({
       line: 2,
@@ -88,7 +98,7 @@ the quick brown fox jumped
     const errors = validateCommands(result.commandNodes, commandProcessors);
     expect(errors.length).toBe(1);
     expect(errors[0].message).toStrictEqual(
-      "missing ID for command: 'code-block'"
+      "attribute list for 'code-block' command should be object"
     );
     expect(errors[0].location).toStrictEqual({
       line: 6,
@@ -116,7 +126,7 @@ the quick brown fox jumped
     const errors = validateCommands(result.commandNodes, commandProcessors);
     expect(errors.length).toBe(2);
     expect(errors[0].message).toStrictEqual(
-      "missing ID for command: 'code-block'"
+      "attribute list for 'code-block' command should be object"
     );
     expect(errors[0].location).toStrictEqual({
       line: 2,
@@ -124,7 +134,7 @@ the quick brown fox jumped
       offset: 4,
     });
     expect(errors[1].message).toStrictEqual(
-      "missing ID for command: 'code-block'"
+      "attribute list for 'code-block' command should be object"
     );
     expect(errors[1].location).toStrictEqual({
       line: 6,
@@ -196,7 +206,7 @@ the quick brown fox jumped
     const errors = validateCommands(result.commandNodes, commandProcessors);
     expect(errors.length).toBe(1);
     expect(errors[0].message).toStrictEqual(
-      "missing ID for command: 'code-block'"
+      "attribute list for 'code-block' command should be object"
     );
     expect(errors[0].location).toStrictEqual({
       line: 2,
@@ -251,5 +261,62 @@ the quick brown fox jumped
       column: 4,
       offset: 102,
     });
+  });
+
+  it("validates block or line mode support on commands", () => {
+    const commandProcessors: CommandProcessors = {
+      lineOnlyCommand: makeLineCommand({
+        process(request) {
+          // do nothing
+        },
+      }),
+      blockOnlyCommand: makeBlockCommand<NoAttributes>({
+        attributesSchema: NoAttributesSchema,
+        process(request) {
+          // do nothing
+        },
+      }),
+      blockOrLineCommand: makeBlockOrLineCommand({
+        attributesSchema: NoAttributesSchema,
+        process(request) {
+          // do nothing
+        },
+      }),
+    };
+
+    const parseResult = parser.parse(`:lineOnlyCommand-start:
+:lineOnlyCommand-end:
+:blockOnlyCommand:
+:blockOrLineCommand:
+:blockOrLineCommand-start:
+:blockOrLineCommand-end:
+`);
+    expect(parseResult.errors).toStrictEqual([]);
+    const visitor = makeCstVisitor(parser);
+    assert(parseResult.cst !== undefined);
+    const result = visitor.visit(parseResult.cst, source);
+    const errors = validateCommands(result.commandNodes, commandProcessors);
+    expect(errors).toStrictEqual([
+      {
+        component: "validator",
+        location: {
+          column: 1,
+          line: 1,
+          offset: 0,
+        },
+        message:
+          "'lineOnlyCommand' cannot be used in block mode (i.e. with -start and -end)",
+      },
+      {
+        component: "validator",
+        location: {
+          column: 1,
+          line: 3,
+          offset: 46,
+        },
+        message:
+          "'blockOnlyCommand' cannot be used in single line mode (i.e. without -start and -end around a block)",
+      },
+    ]);
   });
 });

--- a/src/bluehawk/processor/validator.test.ts
+++ b/src/bluehawk/processor/validator.test.ts
@@ -5,12 +5,16 @@ import { makeBlockCommentTokens } from "../parser/lexer/makeBlockCommentTokens";
 import { makeLineCommentToken } from "../parser/lexer/makeLineCommentToken";
 import { Document } from "../Document";
 import { CommandProcessors } from "./Processor";
+import { makeLineCommand } from "../commands/Command";
 
 describe("validator", () => {
   const commandProcessors: CommandProcessors = {
-    "code-block": {
+    "code-block": makeLineCommand({
       rules: [idIsUnique, hasId],
-    },
+      process(request) {
+        // do nothing
+      },
+    }),
   };
 
   const source = new Document({

--- a/src/bluehawk/processor/validator.test.ts
+++ b/src/bluehawk/processor/validator.test.ts
@@ -9,9 +9,6 @@ import { CommandProcessors } from "./Processor";
 describe("validator", () => {
   const commandProcessors: CommandProcessors = {
     "code-block": {
-      process: () => {
-        return;
-      },
       rules: [idIsUnique, hasId],
     },
   };

--- a/src/bluehawk/processor/validator.ts
+++ b/src/bluehawk/processor/validator.ts
@@ -1,4 +1,8 @@
-import { CommandNode } from "../parser/CommandNode";
+import {
+  BlockCommandNode,
+  CommandNode,
+  LineCommandNode,
+} from "../parser/CommandNode";
 import { BluehawkError } from "../BluehawkError";
 import { flatten } from "../parser/flatten";
 import { CommandProcessors } from "./Processor";
@@ -13,19 +17,21 @@ export interface ValidateCstResult {
 // given command node conforms to the specification of that command. Errors can
 // be reported into the result.errors array.
 export type Rule = (
-  commandNode: CommandNode,
+  commandNode: LineCommandNode | BlockCommandNode,
   result: ValidateCstResult
 ) => void;
 
 export function validateCommands(
-  commandNodes: CommandNode[],
+  commandNodes: (LineCommandNode | BlockCommandNode)[],
   commandProcessorMap: CommandProcessors
 ): BluehawkError[] {
   const validateResult = {
     errors: [],
-    commandsById: new Map<string, CommandNode>(),
+    commandsById: new Map<string, LineCommandNode | BlockCommandNode>(),
   };
-  flatten({ children: commandNodes } as CommandNode).forEach((commandNode) => {
+  flatten({
+    children: commandNodes,
+  } as BlockCommandNode | LineCommandNode).forEach((commandNode) => {
     const processor = commandProcessorMap[commandNode.commandName];
     if (processor === undefined) {
       // TODO: warn unknown command


### PR DESCRIPTION
Really, all that was needed here was a unit test to prove that :remove: can be used as a line command. But there was lacking protection and developer ergonomics around line vs. block command. In particular, someone could use any command name as either a line or block command and there would have to be protection against that built into each command, instead of checked at the validator.

This PR cleans up various odds and ends as well.

## Part 1: Refactor command creation

- Bake in the difference between commands that support line mode, block mode, or both modes.
- Make a helper function to reduce boilerplate and enhance auto-complete support for filling out command implementations.
- Validate in both the validator and in the processor that a given command appears in a mode that the command processor can actually handle.

## Part 2: Remove as line command

- Adds a unit test to prove remove works as a line command.
- That's it.
- No, really.
- I can in fact implement features without huge refactors, but that wouldn't be as fun...
