### PR TITLE
Refactor Command to include its name

### DIFF
--- a/src/bluehawk/bluehawk.test.ts
+++ b/src/bluehawk/bluehawk.test.ts
@@ -10,8 +10,8 @@ import {
 describe("bluehawk", () => {
   const bluehawk = new Bluehawk();
   bluehawk.registerCommand(
-    "code-block",
     makeBlockCommand<IdRequiredAttributes>({
+      name: "code-block",
       attributesSchema: IdRequiredAttributesSchema,
       process(request) {
         return;

--- a/src/bluehawk/bluehawk.ts
+++ b/src/bluehawk/bluehawk.ts
@@ -13,15 +13,35 @@ import * as path from "path";
 import * as fs from "fs";
 import { isBinary } from "istextorbinary";
 
+interface BluehawkConfiguration {
+  commands?: AnyCommand[];
+  commandAliases?: [string, AnyCommand][];
+}
+
 // The frontend of Bluehawk
 export class Bluehawk {
+  constructor(configuration?: BluehawkConfiguration) {
+    if (configuration === undefined) {
+      return;
+    }
+
+    const { commands, commandAliases } = configuration;
+
+    if (commands !== undefined) {
+      commands.forEach((command) => this.registerCommand(command));
+    }
+
+    if (commandAliases !== undefined) {
+      commandAliases.forEach((nameCommandPair) =>
+        this.registerCommand(nameCommandPair[1], nameCommandPair[0])
+      );
+    }
+  }
+
   // Register the given command on the processor and validator. This enables
   // support for the command under the given name.
-  registerCommand<Command extends AnyCommand>(
-    name: string,
-    command: Command
-  ): void {
-    this.processor.registerCommand(name, command);
+  registerCommand(command: AnyCommand, alternateName?: string): void {
+    this.processor.registerCommand(command, alternateName);
   }
 
   // Parses the given source file into commands.

--- a/src/bluehawk/bluehawk.ts
+++ b/src/bluehawk/bluehawk.ts
@@ -10,8 +10,8 @@ import { AnyCommand } from "./commands/Command";
 import { ParseResult } from "./parser/ParseResult";
 import { strict as assert } from "assert";
 import * as path from "path";
-import * as fs from "fs";
 import { isBinary } from "istextorbinary";
+import { System } from "./io/System";
 
 interface BluehawkConfiguration {
   commands?: AnyCommand[];
@@ -89,30 +89,16 @@ export class Bluehawk {
     };
   };
 
-  // Parse the document at the given path.
-  loadFileAndParse = async (sourcePath: string): Promise<ParseResult> => {
-    return new Promise((resolve, reject) => {
-      if (isBinary(sourcePath)) {
-        return reject(
-          new Error(
-            `Binary file encountered at path '${sourcePath}'. Bluehawk does not parse binary files.`
-          )
-        );
-      }
-
-      const language = path.extname(sourcePath);
-      fs.readFile(path.resolve(sourcePath), "utf8", (error, text) => {
-        if (error) {
-          return reject(error);
-        }
-        const document = new Document({ text, language, path: sourcePath });
-        try {
-          resolve(this.parse(document));
-        } catch (error) {
-          reject(error);
-        }
-      });
-    });
+  // Load the document at the given path.
+  readFile = async (sourcePath: string): Promise<Document> => {
+    if (isBinary(sourcePath)) {
+      throw new Error(
+        `Binary file encountered at path '${sourcePath}'. Bluehawk does not parse binary files.`
+      );
+    }
+    const language = path.extname(sourcePath);
+    const text = await System.fs.readFile(path.resolve(sourcePath), "utf8");
+    return new Document({ text, language, path: sourcePath });
   };
 
   // Subscribe to processed documents as they are processed by Bluehawk.

--- a/src/bluehawk/commands/Command.ts
+++ b/src/bluehawk/commands/Command.ts
@@ -4,6 +4,10 @@ import { AnySchema, JSONSchemaType } from "ajv";
 import { AnyCommandNode, BlockCommandNode, LineCommandNode } from "../parser";
 
 interface Command {
+  // The command name. For block commands this should not include -start or
+  // -end.
+  name: string;
+
   // A helpful description of what the command is supposed to do
   description?: string;
 

--- a/src/bluehawk/commands/RemoveCommand.ts
+++ b/src/bluehawk/commands/RemoveCommand.ts
@@ -5,6 +5,7 @@ import {
 } from "./Command";
 
 export const RemoveCommand = makeBlockOrLineCommand<NoAttributes>({
+  name: "remove",
   attributesSchema: NoAttributesSchema,
   process({ commandNode, parseResult }) {
     const { lineRange } = commandNode;

--- a/src/bluehawk/commands/ReplaceCommand.ts
+++ b/src/bluehawk/commands/ReplaceCommand.ts
@@ -9,6 +9,7 @@ type ReplaceCommandAttributes = {
 };
 
 export const ReplaceCommand = makeBlockCommand<ReplaceCommandAttributes>({
+  name: "replace",
   attributesSchema: {
     type: "object",
     required: ["terms"],

--- a/src/bluehawk/commands/SnippetCommand.ts
+++ b/src/bluehawk/commands/SnippetCommand.ts
@@ -60,6 +60,7 @@ function dedentRange(
 }
 
 export const SnippetCommand = makeBlockCommand<IdRequiredAttributes>({
+  name: "snippet",
   attributesSchema: IdRequiredAttributesSchema,
   rules: [idIsUnique],
   process: (request: ProcessRequest<BlockCommandNode>): void => {

--- a/src/bluehawk/commands/StateCommand.ts
+++ b/src/bluehawk/commands/StateCommand.ts
@@ -6,6 +6,7 @@ import {
 import { removeMetaRange } from "./removeMetaRange";
 
 export const StateCommand = makeBlockCommand<IdRequiredAttributes>({
+  name: "state",
   attributesSchema: IdRequiredAttributesSchema,
   process(request) {
     const { commandNode, fork, parseResult } = request;

--- a/src/bluehawk/commands/UncommentCommand.ts
+++ b/src/bluehawk/commands/UncommentCommand.ts
@@ -5,6 +5,7 @@ import { makeBlockCommand, NoAttributes, NoAttributesSchema } from "./Command";
 import { removeMetaRange } from "./removeMetaRange";
 
 export const UncommentCommand = makeBlockCommand<NoAttributes>({
+  name: "uncomment",
   attributesSchema: NoAttributesSchema,
   process(request) {
     const { commandNode, parseResult } = request;

--- a/src/bluehawk/commands/removeCommand.test.ts
+++ b/src/bluehawk/commands/removeCommand.test.ts
@@ -5,7 +5,7 @@ import MagicString from "magic-string";
 
 describe("remove command", () => {
   const bluehawk = new Bluehawk();
-  bluehawk.registerCommand("remove", RemoveCommand);
+  bluehawk.registerCommand(RemoveCommand);
   test("magic string allows double delete", () => {
     // Check assumptions about magic string. At time of writing, magic string
     // docs claim that "removing the same content twice, or making removals that

--- a/src/bluehawk/commands/replaceCommand.test.ts
+++ b/src/bluehawk/commands/replaceCommand.test.ts
@@ -6,9 +6,10 @@ import { SnippetCommand } from "./SnippetCommand";
 
 describe("replace command", () => {
   const bluehawk = new Bluehawk();
-  bluehawk.registerCommand("replace", ReplaceCommand);
-  bluehawk.registerCommand("remove", RemoveCommand);
-  bluehawk.registerCommand("code-block", SnippetCommand);
+  bluehawk.registerCommand(ReplaceCommand);
+  bluehawk.registerCommand(RemoveCommand);
+  bluehawk.registerCommand(SnippetCommand);
+  bluehawk.registerCommand(SnippetCommand, "code-block");
 
   it("errors when no attribute list is given", () => {
     const source = new Document({

--- a/src/bluehawk/commands/snippetCommand.test.ts
+++ b/src/bluehawk/commands/snippetCommand.test.ts
@@ -5,8 +5,8 @@ import { RemoveCommand } from "./RemoveCommand";
 
 describe("snippet Command", () => {
   const bluehawk = new Bluehawk();
-  bluehawk.registerCommand("snippet", SnippetCommand);
-  bluehawk.registerCommand("hide", RemoveCommand);
+  bluehawk.registerCommand(SnippetCommand);
+  bluehawk.registerCommand(RemoveCommand);
 
   it("performs extraction", async (done) => {
     const snippet = `describe("some stuff", () => {
@@ -121,9 +121,9 @@ try! realm.write {
     const source = new Document({
       text: `some text
 // :snippet-start: foo
-// :hide-start:
+// :remove-start:
 hide this
-// :hide-end:
+// :remove-end:
 // :snippet-end:
 `,
       language: "javascript",

--- a/src/bluehawk/commands/stateCommand.test.ts
+++ b/src/bluehawk/commands/stateCommand.test.ts
@@ -7,9 +7,9 @@ import { SnippetCommand } from "./SnippetCommand";
 describe("stateCommand", () => {
   const bluehawk = new Bluehawk();
 
-  bluehawk.registerCommand("state", StateCommand);
-  bluehawk.registerCommand("remove", RemoveCommand);
-  bluehawk.registerCommand("snippet", SnippetCommand);
+  bluehawk.registerCommand(StateCommand);
+  bluehawk.registerCommand(RemoveCommand);
+  bluehawk.registerCommand(SnippetCommand);
 
   it("processes nested commands", async (done) => {
     const multipleInput = new Document({

--- a/src/bluehawk/commands/uncommentCommand.test.ts
+++ b/src/bluehawk/commands/uncommentCommand.test.ts
@@ -5,8 +5,8 @@ import { RemoveCommand } from "./RemoveCommand";
 
 describe("uncomment command", () => {
   const bluehawk = new Bluehawk();
-  bluehawk.registerCommand("uncomment", UncommentCommand);
-  bluehawk.registerCommand("remove", RemoveCommand);
+  bluehawk.registerCommand(UncommentCommand);
+  bluehawk.registerCommand(RemoveCommand);
 
   it("uncomments", async (done) => {
     const source = new Document({

--- a/src/bluehawk/getBluehawk.ts
+++ b/src/bluehawk/getBluehawk.ts
@@ -14,24 +14,13 @@ import {
 
 let bluehawk: Bluehawk | undefined = undefined;
 
-// Returns a standard Bluehawk instance with
+// Returns a standard Bluehawk instance with the given plugins
 export const getBluehawk = async (
   pluginPaths?: string | string[]
 ): Promise<Bluehawk> => {
   if (bluehawk === undefined) {
-    bluehawk = new Bluehawk();
-    bluehawk.registerCommand("code-block", SnippetCommand);
-    bluehawk.registerCommand("replace", ReplaceCommand);
-    bluehawk.registerCommand("snippet", SnippetCommand);
-    bluehawk.registerCommand("remove", RemoveCommand);
-
-    // TODO: "hide" is deprecated and "replace-with" will not work as originally
-    bluehawk.registerCommand("hide", RemoveCommand);
-
-    // hide and replace-with now belong to "state"
-    bluehawk.registerCommand("state", StateCommand);
-
     const StateUncommentCommand = makeBlockCommand<IdRequiredAttributes>({
+      name: "state-uncomment",
       attributesSchema: IdRequiredAttributesSchema,
       process(request) {
         UncommentCommand.process(request);
@@ -39,8 +28,21 @@ export const getBluehawk = async (
       },
     });
 
-    // uncomment the block in the state
-    bluehawk.registerCommand("state-uncomment", StateUncommentCommand);
+    bluehawk = new Bluehawk({
+      commands: [
+        RemoveCommand,
+        ReplaceCommand,
+        SnippetCommand,
+        StateCommand,
+        StateUncommentCommand,
+        UncommentCommand,
+      ],
+      // Aliases for backwards compatibility
+      commandAliases: [
+        ["hide", RemoveCommand],
+        ["code-block", SnippetCommand],
+      ],
+    });
   }
 
   await bluehawk.loadPlugin(pluginPaths);

--- a/src/bluehawk/parseAndProcess.ts
+++ b/src/bluehawk/parseAndProcess.ts
@@ -12,7 +12,8 @@ export async function parseAndProcess(
       onBinaryFile && (await onBinaryFile(filePath));
       return;
     }
-    const result = await bluehawk.loadFileAndParse(filePath);
+    const document = await bluehawk.readFile(filePath);
+    const result = bluehawk.parse(document);
     if (result.errors.length !== 0) {
       console.error(
         `Error in ${filePath}:\n${result.errors

--- a/src/bluehawk/processor/Processor.test.ts
+++ b/src/bluehawk/processor/Processor.test.ts
@@ -15,6 +15,7 @@ describe("processor", () => {
   const bluehawk = new Bluehawk();
 
   const AppendMessageAfterDelayCommand = makeBlockCommand<NoAttributes>({
+    name: "append-message-after-delay",
     attributesSchema: NoAttributesSchema,
     process: (request): Promise<void> => {
       return new Promise((resolve) => {
@@ -32,10 +33,7 @@ describe("processor", () => {
     },
   });
 
-  bluehawk.registerCommand(
-    "append-message-after-delay",
-    AppendMessageAfterDelayCommand
-  );
+  bluehawk.registerCommand(AppendMessageAfterDelayCommand);
 
   it("ignores unknown commands", async (done) => {
     // NOTE: This is not necessarily the desired behavior, but it is the current
@@ -173,6 +171,7 @@ This is probably not a bug in the Bluehawk library itself. Please check with the
       calledBlockCommandProcess: false,
     };
     const LineCommand = makeLineCommand({
+      name: "line-command",
       process({ commandNode }) {
         expect(commandNode.attributes).toBeUndefined();
         expect(commandNode.children).toBeUndefined();
@@ -185,6 +184,7 @@ This is probably not a bug in the Bluehawk library itself. Please check with the
     });
 
     const BlockCommand = makeBlockCommand<IdRequiredAttributes>({
+      name: "block-command",
       attributesSchema: IdRequiredAttributesSchema,
       process({ commandNode }) {
         expect(commandNode.attributes).toBeDefined();
@@ -196,8 +196,8 @@ This is probably not a bug in the Bluehawk library itself. Please check with the
       },
     });
 
-    bluehawk.registerCommand("line-command", LineCommand);
-    bluehawk.registerCommand("block-command", BlockCommand);
+    bluehawk.registerCommand(LineCommand);
+    bluehawk.registerCommand(BlockCommand);
 
     await (async () => {
       const result = bluehawk.parse(

--- a/src/bluehawk/processor/Processor.ts
+++ b/src/bluehawk/processor/Processor.ts
@@ -132,11 +132,8 @@ This is probably not a bug in the Bluehawk library itself. Please check with the
     }, [] as Promise<void>[]);
   };
 
-  registerCommand<Command extends AnyCommand>(
-    name: string,
-    command: Command
-  ): void {
-    this.processors[name] = command;
+  registerCommand(command: AnyCommand, alternateName?: string): void {
+    this.processors[alternateName ?? command.name] = command;
   }
 }
 

--- a/src/bluehawk/processor/validator.test.ts
+++ b/src/bluehawk/processor/validator.test.ts
@@ -19,6 +19,7 @@ import {
 describe("validator", () => {
   const commandProcessors: CommandProcessors = {
     "code-block": makeBlockCommand<IdRequiredAttributes>({
+      name: "code-block",
       attributesSchema: IdRequiredAttributesSchema,
       rules: [idIsUnique],
       process(request) {
@@ -266,17 +267,20 @@ the quick brown fox jumped
   it("validates block or line mode support on commands", () => {
     const commandProcessors: CommandProcessors = {
       lineOnlyCommand: makeLineCommand({
+        name: "lineOnlyCommand",
         process(request) {
           // do nothing
         },
       }),
       blockOnlyCommand: makeBlockCommand<NoAttributes>({
+        name: "blockOnlyCommand",
         attributesSchema: NoAttributesSchema,
         process(request) {
           // do nothing
         },
       }),
       blockOrLineCommand: makeBlockOrLineCommand({
+        name: "blockOrLineCommand",
         attributesSchema: NoAttributesSchema,
         process(request) {
           // do nothing


### PR DESCRIPTION
- Add convenience constructor to Bluehawk
- Still allow alias names for commands