### PR TITLE
Fix uncomment command's overeager comment removal

### DIFF
--- a/src/bluehawk/commands/UncommentCommand.ts
+++ b/src/bluehawk/commands/UncommentCommand.ts
@@ -9,9 +9,9 @@ export const UncommentCommand = makeBlockCommand<NoAttributes>({
   process(request) {
     const { commandNode, parseResult } = request;
     const { source } = parseResult;
-
+    const { text } = source;
     // Strip tags
-    removeMetaRange(source.text, commandNode);
+    removeMetaRange(text, commandNode);
 
     const { contentRange } = commandNode;
     if (contentRange == undefined) {
@@ -30,10 +30,19 @@ export const UncommentCommand = makeBlockCommand<NoAttributes>({
         (lineComment, i) =>
           i === 0 || lineComments[i - 1].startLine !== lineComment.startLine
       )
+      .filter(({ startColumn, startOffset }) => {
+        // Do not delete line comments if they are not the first thing in the
+        // line (after whitespace)
+        assert(startColumn);
+        return (
+          startColumn === 1 ||
+          text.snip(startOffset - (startColumn - 1), startOffset).isEmpty()
+        );
+      })
       .forEach((lineComment) => {
         assert(lineComment.endOffset !== undefined);
         // Delete the line comment
-        source.text.remove(lineComment.startOffset, lineComment.endOffset + 1);
+        text.remove(lineComment.startOffset, lineComment.endOffset + 1);
       });
   },
 });

--- a/src/bluehawk/commands/uncommentCommand.test.ts
+++ b/src/bluehawk/commands/uncommentCommand.test.ts
@@ -79,6 +79,37 @@ no comment
     done();
   });
 
+  it("uncomments only at the beginning of the line (after whitespace if any)", async (done) => {
+    const source = new Document({
+      text: `// :uncomment-start:
+      a//
+leave me alone // comment
+// uncomment this
+leave this alone // // double comment
+  // uncomment this // double comment
+\t\t// uncomment this
+\t\tnot this // though
+// :uncomment-end:
+`,
+      language: "javascript",
+      path: "uncomment.test.js",
+    });
+
+    const parseResult = bluehawk.parse(source);
+    const files = await bluehawk.process(parseResult);
+    expect(files["uncomment.test.js"].source.text.toString()).toBe(
+      `      a//
+leave me alone // comment
+uncomment this
+leave this alone // // double comment
+  uncomment this // double comment
+\t\tuncomment this
+\t\tnot this // though
+`
+    );
+    done();
+  });
+
   it("pairs with remove", async (done) => {
     const source = new Document({
       text: `// :uncomment-start:
@@ -86,6 +117,8 @@ no comment
 // :remove-start:
 // // // //
 no comment
+       a // a
+             \t\t     // spaced out comment
 // :remove-end:
 // // double comment
 // :uncomment-end:


### PR DESCRIPTION
- "Uncomment" should only remove a layer of comments at the start of a line (give or take any whitespace)
- Add supporting unit tests to verify
