### PR TITLE
Fix nested code block in parser

### DIFF
--- a/src/bluehawk/parser/RootParser.ts
+++ b/src/bluehawk/parser/RootParser.ts
@@ -57,7 +57,7 @@ blockCommand
   : (LineComment)? CommandStart (commandAttribute)? Newline (chunk)* (LineComment)* CommandEnd
 
 blockComment
-  : BlockCommentStart (command | LineComment | NewLine | blockComment†)* BlockCommentEnd
+  : BlockCommentStart (command | LineComment | NewLine | BlockCommentStart†)* BlockCommentEnd
 
 chunk
   : (command | blockComment | lineComment | pushParser | StringLiteral)* (Newline | EOF)††
@@ -192,9 +192,8 @@ export class RootParser extends CstParser {
           { ALT: () => this.CONSUME(LineComment) },
           { ALT: () => this.CONSUME(Newline) },
           {
-            // Only if explicitly set to `false` does this forbid nesting
             GATE: () => startToken.payload?.canNest !== false,
-            ALT: () => this.SUBRULE(this.blockComment),
+            ALT: () => this.CONSUME1(BlockCommentStart),
           },
         ])
       );


### PR DESCRIPTION
- By using 'blockComment' instead of 'BlockCommentStart' when nesting is allowed,
nested comments would require a nested closing block comment token. This isn't
how any languages I know of actually work - additional BlockCommentStarts should
be ignored.