### PR TITLE
Update plugin architecture

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "bugs": {
     "url": "https://github.com/mongodb-university/Bluehawk/issues"
   },
-  "main": "./build/src/cli",
+  "main": "./build/src",
   "bin": {
     "bluehawk": "./build/src/cli/index.js"
   },

--- a/src/bluehawk/bluehawk.ts
+++ b/src/bluehawk/bluehawk.ts
@@ -197,53 +197,10 @@ This is probably a bug in Bluehawk. Please send this stack trace (and the conten
     return this._processor.process(parseResult, processOptions);
   };
 
-  /**
-    Load the given plugin(s). A plugin is a js file or module that exports a
-    `register(bluehawk)` function. `register()` takes this bluehawk instance
-    and can register commands, add listeners, etc. The plugin at a given path
-    will only be loaded once.
-   */
-  loadPlugin = async (
-    pluginPath: string | string[] | undefined
-  ): Promise<void> => {
-    if (pluginPath === undefined) {
-      return;
-    }
-
-    if (Array.isArray(pluginPath)) {
-      const promises = pluginPath.map((path) => this.loadPlugin(path));
-      await Promise.allSettled(promises);
-      return;
-    }
-
-    if (typeof pluginPath !== "string") {
-      console.warn(
-        `Invalid argument to loadPlugin: ${pluginPath} (typeof == ${typeof pluginPath}`
-      );
-      return;
-    }
-
-    // Check if the plugin has already been loaded
-    if (this._loadedPlugins.has(pluginPath)) {
-      console.warn(`Skipping already loaded plugin: ${pluginPath}`);
-      return;
-    }
-
-    // Convert relative path (from user's cwd) to absolute path -- as import()
-    // expects relative paths from Bluehawk bin directory
-    const absolutePath = Path.isAbsolute(pluginPath)
-      ? pluginPath
-      : Path.resolve(process.cwd(), pluginPath);
-    const plugin = await import(absolutePath);
-    await plugin.register(this);
-    this._loadedPlugins.add(pluginPath);
-  };
-
   get processor(): Processor {
     return this._processor;
   }
 
   private _processor = new Processor();
   private _parserStore = new ParserStore();
-  private _loadedPlugins = new Set<string>();
 }

--- a/src/bluehawk/getBluehawk.ts
+++ b/src/bluehawk/getBluehawk.ts
@@ -16,10 +16,10 @@ import {
 
 let bluehawk: Bluehawk | undefined = undefined;
 
-// Returns a standard Bluehawk instance with the given plugins
-export const getBluehawk = async (
-  pluginPaths?: string | string[]
-): Promise<Bluehawk> => {
+/**
+  Returns a standard, shared Bluehawk instance.
+ */
+export const getBluehawk = async (): Promise<Bluehawk> => {
   if (bluehawk === undefined) {
     const StateUncommentCommand = makeBlockCommand<IdRequiredAttributes>({
       name: "state-uncomment",
@@ -101,7 +101,6 @@ export const getBluehawk = async (
     });
   }
 
-  await bluehawk.loadPlugin(pluginPaths);
   return bluehawk;
 };
 

--- a/src/cli/Plugin.ts
+++ b/src/cli/Plugin.ts
@@ -1,0 +1,98 @@
+import * as Path from "path";
+import { Argv } from "yargs";
+import { Bluehawk } from "../bluehawk";
+
+/**
+  A plugin is a Node module that exports a register() function.
+
+  A plugin can be a simple JS file or a transpiled Node module,
+  as long as it exports the register() function:
+
+    // MyPlugin.js
+    exports.register = (args) => {
+      // Add a new CLI option
+      args.yargs.option("myNewOption", { string: true });
+
+      // Add Bluehawk listener
+      args.bluehawk.subscribe((result) => {
+        console.log("Plugin called for file", result.document.path);
+      });
+    };
+
+  You can then call `bluehawk --plugin /path/to/MyPlugin.js` to use the plugin.
+ */
+export type Plugin = {
+  /**
+    The CLI calls this function to allow the plugin to modify the main
+    [[Bluehawk]] instance or the CLI itself.
+   */
+  register(args: PluginArgs): Promise<void> | void;
+};
+
+export type LoadedPlugin = Plugin & {
+  /**
+    The path to the plugin as provided to the CLI by the --plugin option.
+   */
+  path: string;
+};
+
+/**
+  The arguments passed from the CLI to a plugin's register() function.
+ */
+export interface PluginArgs {
+  /**
+    The [[Bluehawk]] instance that a plugin can use to add Bluehawk commands,
+    languages, and listeners.
+  */
+  bluehawk: Bluehawk;
+
+  /**
+    The [yargs](https://yargs.js.org/) instance that a plugin can modify to add
+    CLI commands and options.
+   */
+  yargs: Argv;
+
+  /**
+    The current semantic version string of Bluehawk.
+   */
+  bluehawkVersion: string;
+
+  /**
+    The current semantic version string of Yargs.
+   */
+  yargsVersion: string;
+}
+
+/**
+  Load the given plugin(s).
+ */
+export const loadPlugins = async (
+  path: string | string[] | undefined
+): Promise<LoadedPlugin[]> => {
+  if (path === undefined) {
+    return [];
+  }
+
+  if (Array.isArray(path)) {
+    const plugins = await Promise.all(path.map((path) => loadPlugins(path)));
+    return plugins.flat();
+  }
+
+  // Convert potentially relative path (from user's cwd) to absolute path -- as
+  // import() expects relative paths from Bluehawk bin directory
+  const absolutePath = Path.resolve(path);
+  const { register } = await import(absolutePath);
+
+  if (typeof register !== "function") {
+    throw new Error(
+      `loading plugin '${path}': expected function register(args) to be exported`
+    );
+  }
+
+  return [
+    {
+      path,
+      register,
+    },
+  ];
+};

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,5 +1,8 @@
 import * as yargs from "yargs";
-import { withPluginOption } from "./options";
+import { getBluehawk } from "../bluehawk";
+import { loadPlugins } from "./Plugin";
+import { version as yargsVersion } from "yargs/package.json";
+import { version as bluehawkVersion } from "../../package.json";
 
 export interface MainArgs {
   plugin?: string | string[];
@@ -14,7 +17,7 @@ export function commandDir<T>(
   // Centralize the workaround for commandDir with TS
   return argv.commandDir(directory, {
     extensions: process.env.NODE_ENV === "development" ? ["js", "ts"] : ["js"],
-    exclude: /\.test\.[jt]s$/,
+    exclude: /^(?:index|.*\.test)\.[jt]s$/,
     visit(commandModule) {
       return commandModule.default;
     },
@@ -23,5 +26,34 @@ export function commandDir<T>(
 }
 
 export async function run(): Promise<void> {
-  commandDir(withPluginOption(yargs.help()), "commands").demandCommand().argv;
+  const preArgv = yargs.option("plugin", {
+    string: true,
+    describe: "add a plugin",
+  }).argv;
+
+  const mainArgv = commandDir(yargs.help(), "commands").demandCommand();
+
+  const plugins = await loadPlugins(preArgv.plugin);
+
+  const bluehawk = await getBluehawk();
+
+  const pluginPromises = plugins.map(async (plugin) => {
+    const { path, register } = plugin;
+    try {
+      await register({
+        bluehawk,
+        bluehawkVersion,
+        yargs: mainArgv,
+        yargsVersion,
+      });
+    } catch (error) {
+      error.message = `Plugin '${path}' register() failed with error: ${error.message}`;
+      throw error;
+    }
+  });
+
+  await Promise.all(pluginPromises);
+
+  // Accessing this property executes CLI
+  mainArgv.argv;
 }

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -12,8 +12,8 @@ interface CheckArgs extends MainArgs {
 }
 
 export const check = async (args: Arguments<CheckArgs>): Promise<void> => {
-  const { ignore, json, paths, plugin } = args;
-  const bluehawk = await getBluehawk(plugin);
+  const { ignore, json, paths } = args;
+  const bluehawk = await getBluehawk();
   const fileToErrorMap = new Map<string, BluehawkError[]>();
 
   const addErrors = (filePath: string, errors: BluehawkError[]) => {

--- a/src/cli/commands/copy.ts
+++ b/src/cli/commands/copy.ts
@@ -1,7 +1,7 @@
 import { Stats } from "fs";
 import * as path from "path";
 import { CommandModule, Arguments, Argv } from "yargs";
-import { ParseResult, getBluehawk } from "../../bluehawk";
+import { getBluehawk } from "../../bluehawk";
 import { MainArgs } from "../cli";
 import {
   withDestinationOption,
@@ -18,10 +18,10 @@ export interface CopyArgs extends MainArgs {
 }
 
 export const copy = async (args: CopyArgs): Promise<string[]> => {
-  const { destination, ignore, plugin, rootPath } = args;
+  const { destination, ignore, rootPath } = args;
   const desiredState = args.state;
   const errors: string[] = [];
-  const bluehawk = await getBluehawk(plugin);
+  const bluehawk = await getBluehawk();
   let stats: Stats;
   try {
     stats = await System.fs.lstat(rootPath);

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -1,0 +1,5 @@
+export * from "./check";
+export * from "./copy";
+export * from "./list/";
+export * from "./list";
+export * from "./snip";

--- a/src/cli/commands/list/commands.ts
+++ b/src/cli/commands/list/commands.ts
@@ -7,8 +7,8 @@ import { printJsonResult } from "../../printJsonResult";
 const handler = async (
   args: Arguments<MainArgs & { json?: boolean }>
 ): Promise<void> => {
-  const { plugin, json } = args;
-  const bluehawk = await getBluehawk(plugin);
+  const { json } = args;
+  const bluehawk = await getBluehawk();
 
   const { processor } = bluehawk;
   const { processors } = processor;

--- a/src/cli/commands/list/index.ts
+++ b/src/cli/commands/list/index.ts
@@ -1,0 +1,2 @@
+export * from "./commands";
+export * from "./states";

--- a/src/cli/commands/list/states.ts
+++ b/src/cli/commands/list/states.ts
@@ -13,8 +13,8 @@ interface ListStatesArgs extends MainArgs {
 export const listStates = async (
   args: Arguments<ListStatesArgs>
 ): Promise<void> => {
-  const { ignore, json, paths, plugin } = args;
-  const bluehawk = await getBluehawk(plugin);
+  const { ignore, json, paths } = args;
+  const bluehawk = await getBluehawk();
 
   const statesFound = new Set<string>();
   bluehawk.subscribe((result) => {

--- a/src/cli/commands/snip.ts
+++ b/src/cli/commands/snip.ts
@@ -85,16 +85,8 @@ export const doRst = async (
 };
 
 export const snip = async (args: SnipArgs): Promise<void> => {
-  const {
-    paths,
-    destination,
-    plugin,
-    state,
-    ignore,
-    format,
-    waitForListeners,
-  } = args;
-  const bluehawk = await getBluehawk(plugin);
+  const { paths, destination, state, ignore, format, waitForListeners } = args;
+  const bluehawk = await getBluehawk();
 
   // If a file contains the state command, the processor will generate multiple
   // versions of the same file. Keep track of whether a state file was written

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
+export * from "./Plugin";
+export * from "./cli";
+export * from "./commands";
+export * from "./options";
+export * from "./printJsonResult";
 
 import { run } from "./cli";
 

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -36,15 +36,6 @@ export function withIgnoreOption<T>(
   });
 }
 
-export function withPluginOption<T>(
-  yargs: Argv<T>
-): Argv<T & { plugin?: string | string[] }> {
-  return option(yargs, "plugin", {
-    string: true,
-    describe: "add a plugin",
-  });
-}
-
 export function withStateOption<T>(
   yargs: Argv<T>
 ): Argv<T & { state?: string }> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./cli";
+export * from "./bluehawk";


### PR DESCRIPTION
- Load plugins before anything else in CLI
- Give plugins the opportunity to modify CLI itself (via Yargs)
- Pass bluehawk and yargs versions to plugins in case of version drift