### PR TITLE
actually process explicit files passed in

### DIFF
--- a/src/bluehawk/bluehawk.ts
+++ b/src/bluehawk/bluehawk.ts
@@ -114,7 +114,7 @@ export class Bluehawk {
 
     const promises = filePaths.map(async (filePath) => {
       try {
-        const blob = await System.fs.readFile(Path.resolve(filePath));
+        const blob = await System.fs.readFile(filePath);
         if (isBinary(filePath, blob)) {
           onBinaryFile && (await onBinaryFile(filePath));
           return;

--- a/src/bluehawk/bluehawk.ts
+++ b/src/bluehawk/bluehawk.ts
@@ -112,30 +112,28 @@ export class Bluehawk {
       ignore,
     });
 
-    const promises = filePaths
-      .map((filePath) => Path.join(path, filePath))
-      .map(async (filePath) => {
-        try {
-          const blob = await System.fs.readFile(Path.resolve(filePath));
-          if (isBinary(filePath, blob)) {
-            onBinaryFile && (await onBinaryFile(filePath));
-            return;
-          }
-          const text = blob.toString("utf8");
-          const document = new Document({ text, path: filePath });
-          const result = this.parse(document);
-          if (result.errors.length !== 0) {
-            onErrors && onErrors(filePath, result.errors);
-            return;
-          }
-          await this.process(result, options);
-        } catch (e) {
-          console.error(`Encountered the following error while processing ${filePath}:
+    const promises = filePaths.map(async (filePath) => {
+      try {
+        const blob = await System.fs.readFile(Path.resolve(filePath));
+        if (isBinary(filePath, blob)) {
+          onBinaryFile && (await onBinaryFile(filePath));
+          return;
+        }
+        const text = blob.toString("utf8");
+        const document = new Document({ text, path: filePath });
+        const result = this.parse(document);
+        if (result.errors.length !== 0) {
+          onErrors && onErrors(filePath, result.errors);
+          return;
+        }
+        await this.process(result, options);
+      } catch (e) {
+        console.error(`Encountered the following error while processing ${filePath}:
 ${e.stack}
 
 This is probably a bug in Bluehawk. Please send this stack trace (and the contents of ${filePath}, if possible) to the Bluehawk development team at https://github.com/mongodb-university/Bluehawk/issues/new`);
-        }
-      });
+      }
+    });
 
     await Promise.allSettled(promises);
   };

--- a/src/bluehawk/project/loadProjectPaths.test.ts
+++ b/src/bluehawk/project/loadProjectPaths.test.ts
@@ -20,6 +20,21 @@ describe("loadProjectPaths", () => {
     expect(paths).toStrictEqual(["test/foo.txt"]);
   });
 
+  it("loads files", async () => {
+    System.fs.mkdir(Path.resolve("virtual/testProject/test/"), {
+      recursive: true,
+    });
+    System.fs.writeFile(
+      Path.resolve("virtual/testProject/test/foo.txt"),
+      "hello, world!"
+    );
+    const paths = await loadProjectPaths({
+      rootPath: "virtual/testProject/test/foo.txt",
+    });
+
+    expect(paths).toStrictEqual([""]);
+  });
+
   it("ignores specified paths", async () => {
     System.useJsonFs({
       "/path/to/project/a.txt": "",

--- a/src/bluehawk/project/loadProjectPaths.test.ts
+++ b/src/bluehawk/project/loadProjectPaths.test.ts
@@ -17,22 +17,27 @@ describe("loadProjectPaths", () => {
       rootPath: "virtual/testProject",
     });
 
-    expect(paths).toStrictEqual(["test/foo.txt"]);
+    // paths actually contain full filesystem path, so just checking the suffix
+    expect(paths[0].endsWith("test/foo.txt")).toBeTruthy();
   });
 
   it("loads files", async () => {
-    System.fs.mkdir(Path.resolve("virtual/testProject/test/"), {
+    System.fs.mkdir(Path.resolve("/path/to/project/test/"), {
       recursive: true,
     });
     System.fs.writeFile(
-      Path.resolve("virtual/testProject/test/foo.txt"),
+      Path.resolve("/path/to/project/test/foo.txt"),
       "hello, world!"
     );
     const paths = await loadProjectPaths({
-      rootPath: "virtual/testProject/test/foo.txt",
+      rootPath: "/path/to/project/test/foo.txt",
     });
 
-    expect(paths).toStrictEqual([""]);
+    expect(
+      await loadProjectPaths({
+        rootPath: "/path/to/project",
+      })
+    ).toStrictEqual(["/path/to/project/test/foo.txt"]);
   });
 
   it("ignores specified paths", async () => {
@@ -51,13 +56,13 @@ describe("loadProjectPaths", () => {
         rootPath: "/path/to/project",
       })
     ).toStrictEqual([
-      "a.txt",
-      "b.txt",
-      "c.json",
-      "d.json",
-      "foo/d.json",
-      "foo/d.txt",
-      "foo/e.txt",
+      "/path/to/project/a.txt",
+      "/path/to/project/b.txt",
+      "/path/to/project/c.json",
+      "/path/to/project/d.json",
+      "/path/to/project/foo/d.json",
+      "/path/to/project/foo/d.txt",
+      "/path/to/project/foo/e.txt",
     ]);
 
     expect(
@@ -65,28 +70,48 @@ describe("loadProjectPaths", () => {
         rootPath: "/path/to/project",
         ignore: "*.txt",
       })
-    ).toStrictEqual(["c.json", "d.json", "foo/d.json"]);
+    ).toStrictEqual([
+      "/path/to/project/c.json",
+      "/path/to/project/d.json",
+      "/path/to/project/foo/d.json",
+    ]);
 
     expect(
       await loadProjectPaths({
         rootPath: "/path/to/project",
         ignore: "**/*.json",
       })
-    ).toStrictEqual(["a.txt", "b.txt", "foo/d.txt", "foo/e.txt"]);
+    ).toStrictEqual([
+      "/path/to/project/a.txt",
+      "/path/to/project/b.txt",
+      "/path/to/project/foo/d.txt",
+      "/path/to/project/foo/e.txt",
+    ]);
 
     expect(
       await loadProjectPaths({
         rootPath: "/path/to/project",
         ignore: ["d.*"],
       })
-    ).toStrictEqual(["a.txt", "b.txt", "c.json", "foo/e.txt"]);
+    ).toStrictEqual([
+      "/path/to/project/a.txt",
+      "/path/to/project/b.txt",
+      "/path/to/project/c.json",
+      "/path/to/project/foo/e.txt",
+    ]);
 
     expect(
       await loadProjectPaths({
         rootPath: "/path/to/project",
         ignore: "foo/*.txt",
       })
-    ).toStrictEqual(["a.txt", "b.txt", "c.json", "d.json", "foo/d.json"]);
+    ).toStrictEqual([
+      "/path/to/project/a.txt",
+      "/path/to/project/b.txt",
+      "/path/to/project/c.json",
+      "/path/to/project/d.json",
+      "/path/to/project/foo/d.json",
+    ]);
   });
 
   it("ignores gitignored paths", async () => {
@@ -116,11 +141,11 @@ foo/
         rootPath: "/path/to/project",
       })
     ).toStrictEqual([
-      ".gitignore",
+      "/path/to/project/.gitignore",
       // "a.txt", // ignored
-      "b.txt",
-      "bar/.gitignore",
-      "bar/bar.txt",
+      "/path/to/project/b.txt",
+      "/path/to/project/bar/.gitignore",
+      "/path/to/project/bar/bar.txt",
       // "bar/a.gif",
       // "c.json", // ignored
       // "d.json", // ignored

--- a/src/bluehawk/project/loadProjectPaths.ts
+++ b/src/bluehawk/project/loadProjectPaths.ts
@@ -8,16 +8,20 @@ async function traverse(
   projectRoot: string,
   ignores: string[]
 ): Promise<string[]> {
-  if (absolutePath === projectRoot) {
-    // special handling -- when run on individual files, bluehawk path already contains file name
-    return [absolutePath];
-  }
   const ig = ignore();
   ig.add(ignores);
   const stats = await System.fs.lstat(absolutePath);
   const relativePath = path.relative(projectRoot, absolutePath);
-  if (stats.isFile() && !ig.ignores(relativePath)) {
-    return [absolutePath];
+  if (stats.isFile()) {
+    if (absolutePath === projectRoot) {
+      // special handling -- when run on individual files, bluehawk path already contains file name
+      return [absolutePath];
+    }
+    if (ig.ignores(relativePath)) {
+      return [];
+    } else {
+      return [absolutePath];
+    }
   } else if (!stats.isDirectory()) {
     return [];
   }

--- a/src/bluehawk/project/loadProjectPaths.ts
+++ b/src/bluehawk/project/loadProjectPaths.ts
@@ -12,7 +12,8 @@ async function traverse(
   ig.add(ignores);
   const stats = await System.fs.lstat(absolutePath);
   const relativePath = path.relative(projectRoot, absolutePath);
-  if (stats.isFile() && !ig.ignores(relativePath)) {
+  // special handling for empty relativePath when a file is explicitly passed in
+  if (stats.isFile() && (relativePath ? !ig.ignores(relativePath) : true)) {
     return [relativePath];
   }
   if (!stats.isDirectory()) {

--- a/src/bluehawk/project/loadProjectPaths.ts
+++ b/src/bluehawk/project/loadProjectPaths.ts
@@ -8,23 +8,17 @@ async function traverse(
   projectRoot: string,
   ignores: string[]
 ): Promise<string[]> {
+  if (absolutePath === projectRoot) {
+    // special handling -- when run on individual files, bluehawk path already contains file name
+    return [absolutePath];
+  }
   const ig = ignore();
   ig.add(ignores);
   const stats = await System.fs.lstat(absolutePath);
   const relativePath = path.relative(projectRoot, absolutePath);
-  if (stats.isFile()) {
-    // files nested at least one level within a project directory
-    if (relativePath !== "") {
-      if (ig.ignores(relativePath)) {
-        return [];
-      } else {
-        return [absolutePath];
-      }
-    }
-    // special handling -- when run on individual files, bluehawk path already contains file name
+  if (stats.isFile() && !ig.ignores(relativePath)) {
     return [absolutePath];
-  }
-  if (!stats.isDirectory()) {
+  } else if (!stats.isDirectory()) {
     return [];
   }
 

--- a/src/bluehawk/project/loadProjectPaths.ts
+++ b/src/bluehawk/project/loadProjectPaths.ts
@@ -19,10 +19,10 @@ async function traverse(
     }
     if (ig.ignores(relativePath)) {
       return [];
-    } else {
-      return [absolutePath];
     }
-  } else if (!stats.isDirectory()) {
+    return [absolutePath];
+  }
+  if (!stats.isDirectory()) {
     return [];
   }
 

--- a/src/bluehawk/project/loadProjectPaths.ts
+++ b/src/bluehawk/project/loadProjectPaths.ts
@@ -18,11 +18,11 @@ async function traverse(
       if (ig.ignores(relativePath)) {
         return [];
       } else {
-        return [relativePath];
+        return [absolutePath];
       }
     }
     // special handling -- when run on individual files, bluehawk path already contains file name
-    return [""];
+    return [absolutePath];
   }
   if (!stats.isDirectory()) {
     return [];

--- a/src/bluehawk/project/loadProjectPaths.ts
+++ b/src/bluehawk/project/loadProjectPaths.ts
@@ -12,9 +12,17 @@ async function traverse(
   ig.add(ignores);
   const stats = await System.fs.lstat(absolutePath);
   const relativePath = path.relative(projectRoot, absolutePath);
-  // special handling for empty relativePath when a file is explicitly passed in
-  if (stats.isFile() && (relativePath ? !ig.ignores(relativePath) : true)) {
-    return [relativePath];
+  if (stats.isFile()) {
+    // files nested at least one level within a project directory
+    if (relativePath !== "") {
+      if (ig.ignores(relativePath)) {
+        return [];
+      } else {
+        return [relativePath];
+      }
+    }
+    // special handling -- when run on individual files, bluehawk path already contains file name
+    return [""];
   }
   if (!stats.isDirectory()) {
     return [];


### PR DESCRIPTION
It seems that passing `ignore.ignores()` an empty string causes... problems (crashes entire program silently, swallowing error message)