### PR TITLE
Remove duplicate language extension spec

### DIFF
--- a/src/bluehawk/getBluehawk.ts
+++ b/src/bluehawk/getBluehawk.ts
@@ -70,7 +70,6 @@ export const getBluehawk = async (): Promise<Bluehawk> => {
         ".gvy",
         ".gy",
         ".gsh",
-        ".uxml"
       ],
       {
         languageId: "C-like",


### PR DESCRIPTION
Quash the warning "overriding language specification for extension 'uxml'" - note uxml is still below in XML-likes
