### PR TITLE
patch: add install bluehawk scripts to ci

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -14,6 +14,9 @@ jobs:
         with:
           node-version: 14.x
           cache: npm
+      - name: Install Bluehawk dependencies
+        run: |
+          npm ci
       - name: Build website
         working-directory: docs
         run: |

--- a/.github/workflows/test-deploy-docs.yaml
+++ b/.github/workflows/test-deploy-docs.yaml
@@ -16,6 +16,9 @@ jobs:
         with:
           node-version: 14.x
           cache: npm
+      - name: Install Bluehawk dependencies
+        run: |
+          npm ci
       - name: Test build
         working-directory: docs
         run: |


### PR DESCRIPTION
fix issue where api docs not building b/c they don't have npm dependencies. 