### PR TITLE
Use absolute paths to locate commandModules

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,3 +1,4 @@
+import * as Path from "path";
 import * as yargs from "yargs";
 import { getBluehawk, loadPlugins, commandDir } from "../bluehawk";
 import { version as yargsVersion } from "yargs/package.json";
@@ -9,7 +10,7 @@ export async function run(): Promise<void> {
     describe: "add a plugin",
   }).argv;
 
-  const mainArgv = commandDir(yargs.help(), "commandModules").demandCommand();
+  const mainArgv = commandDir(yargs.help(), Path.join(__dirname, "commandModules")).demandCommand();
 
   const plugins = await loadPlugins(preArgv.plugin);
 

--- a/src/cli/commandModules/list.ts
+++ b/src/cli/commandModules/list.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 const commandModule: yargs.CommandModule = {
   command: "list",
   builder(yargs) {
-    return commandDir(yargs, path.join("commandModules", "list"));
+    return commandDir(yargs, path.join(__dirname, "list"));
   },
   handler() {
     yargs.showHelp();


### PR DESCRIPTION
- Since moving the commandDir() function, relative paths were broken