### PR TITLE
Change `--destination/-d` flag to `--output/-o`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ npm run build
 If compilation is successful, you can run bluehawk like so:
 
 ```sh
-node build/src/cli/main.js snip -d <destination directory> <folder to source file or directory>
+node build/src/cli/main.js snip -o <output directory> <folder to source file or directory>
 ```
 
 Which you can alias as:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,13 +15,13 @@ npm run build
 If compilation is successful, you can run bluehawk like so:
 
 ```sh
-node build/src/cli/main.js snip -o <output directory> <folder to source file or directory>
+node build/src/main.js snip -o <output directory> <folder to source file or directory>
 ```
 
 Which you can alias as:
 
 ```sh
-alias bluehawk-dev="node /path/to/bluehawk/build/src/cli/main.js"
+alias bluehawk-dev="node /path/to/bluehawk/build/src/main.js"
 ```
 
 # Running Tests

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -14,7 +14,7 @@ code blocks, full files of code, and even error checks.
 ### Snip
 
 ```
-bluehawk snip --destination <output-directory> <input-directory-or-file>
+bluehawk snip --output <output-directory> <input-directory-or-file>
 ```
 
 Output "snippet files" that contain only the content of `code-block` or
@@ -28,11 +28,11 @@ content from a single state that you specify.
 ### Copy
 
 ```
-bluehawk copy --destination <output-directory> <input-directory-or-file>
+bluehawk copy --output <output-directory> <input-directory-or-file>
 ```
 
 Output full bluehawk-processed input files, in their original directory
-structure, to destination directory. Binary files are copied without
+structure, to output directory. Binary files are copied without
 Bluehawk processing. You can use the `--ignore` flag to add gitignore-style
 ignore patterns that omit matched files from output.
 By default, this command generates output files that omit all `state`.

--- a/docs/docs/use-cases.md
+++ b/docs/docs/use-cases.md
@@ -123,5 +123,5 @@ implementation code, but no "TODO":
 ```
 
 You can run Bluehawk on an entire directory, and each file in the repo will be
-copied or transformed to the destination. This makes it easy to copy one state
+copied or transformed to the output directory. This makes it easy to copy one state
 of the entire tutorial source into another repo that learners can clone.

--- a/src/bluehawk/actions/ActionReporter.ts
+++ b/src/bluehawk/actions/ActionReporter.ts
@@ -55,7 +55,7 @@ export type FileParsedEvent = FileEvent & {
 };
 
 export type FileWrittenEvent = FileEvent & {
-  destinationPath: string;
+  outputPath: string;
   type: "text" | "binary";
 };
 

--- a/src/bluehawk/actions/ConsoleActionReporter.test.ts
+++ b/src/bluehawk/actions/ConsoleActionReporter.test.ts
@@ -23,7 +23,7 @@ const dummyReport = (reporter: ActionReporter) => {
     },
   });
   reporter.onFileWritten({
-    destinationPath: "foo",
+    outputPath: "foo",
     sourcePath: "bar",
     type: "text",
   });
@@ -46,7 +46,7 @@ const dummyReport = (reporter: ActionReporter) => {
   });
   reporter.onWriteFailed({
     type: "text",
-    destinationPath: "foo",
+    outputPath: "foo",
     sourcePath: "bar",
     error: new Error(),
   });

--- a/src/bluehawk/actions/ConsoleActionReporter.ts
+++ b/src/bluehawk/actions/ConsoleActionReporter.ts
@@ -49,7 +49,7 @@ export class ConsoleActionReporter implements ActionReporter {
     ++this._count.filesWritten;
     if (this.logLevel >= LogLevel.Info) {
       console.log(
-        `wrote ${event.type} file based on ${event.sourcePath} -> ${event.destinationPath}`
+        `wrote ${event.type} file based on ${event.sourcePath} -> ${event.outputPath}`
       );
     }
   }
@@ -85,7 +85,7 @@ export class ConsoleActionReporter implements ActionReporter {
     ++this._count.errors;
     if (this.logLevel >= LogLevel.Error) {
       console.error(
-        `failed to write file ${event.sourcePath} -> ${event.destinationPath}: ${event.error.message}`
+        `failed to write file ${event.sourcePath} -> ${event.outputPath}: ${event.error.message}`
       );
     }
   }

--- a/src/bluehawk/actions/copy.test.ts
+++ b/src/bluehawk/actions/copy.test.ts
@@ -9,18 +9,18 @@ describe("copy", () => {
 
   it("copies", async () => {
     const rootPath = "/path/to/project";
-    const destinationPath = "/destination";
+    const outputPath = "/output";
     await System.fs.mkdir(rootPath, {
       recursive: true,
     });
-    await System.fs.mkdir(destinationPath, {
+    await System.fs.mkdir(outputPath, {
       recursive: true,
     });
     await System.fs.writeFile(Path.join(rootPath, "test.txt"), "utf8");
     const reporter = new ConsoleActionReporter();
     await copy({
       reporter,
-      destination: destinationPath,
+      output: outputPath,
       rootPath,
       waitForListeners: true,
     });
@@ -28,17 +28,17 @@ describe("copy", () => {
     expect(reporter.errorCount).toBe(0);
     const sourceList = await System.fs.readdir(rootPath);
     expect(sourceList).toStrictEqual(["test.txt"]);
-    const destinationList = await System.fs.readdir(destinationPath);
-    expect(destinationList).toStrictEqual(sourceList);
+    const outputList = await System.fs.readdir(outputPath);
+    expect(outputList).toStrictEqual(sourceList);
   });
 
   it("copies binary files", async () => {
     const rootPath = "/path/to/project";
-    const destinationPath = "/destination";
+    const outputPath = "/output";
     await System.fs.mkdir(rootPath, {
       recursive: true,
     });
-    await System.fs.mkdir(destinationPath, {
+    await System.fs.mkdir(outputPath, {
       recursive: true,
     });
     const filePath = Path.join(rootPath, "test.bin");
@@ -47,7 +47,7 @@ describe("copy", () => {
     const reporter = new ConsoleActionReporter();
     await copy({
       reporter,
-      destination: destinationPath,
+      output: outputPath,
       rootPath,
       onBinaryFile(path) {
         didCallBinaryFileForPath = path;
@@ -58,18 +58,18 @@ describe("copy", () => {
     expect(reporter.errorCount).toBe(0);
     const sourceList = await System.fs.readdir(rootPath);
     expect(sourceList).toStrictEqual(["test.bin"]);
-    const destinationList = await System.fs.readdir(destinationPath);
-    expect(destinationList).toStrictEqual(sourceList);
+    const outputList = await System.fs.readdir(outputPath);
+    expect(outputList).toStrictEqual(sourceList);
     expect(didCallBinaryFileForPath).toBe(filePath);
   });
 
   it("copies permissions", async () => {
     const rootPath = "/path/to/project";
-    const destinationPath = "/destination";
+    const outputPath = "/output";
     await System.fs.mkdir(rootPath, {
       recursive: true,
     });
-    await System.fs.mkdir(destinationPath, {
+    await System.fs.mkdir(outputPath, {
       recursive: true,
     });
     const binPath = Path.join(rootPath, "test.bin");
@@ -81,7 +81,7 @@ describe("copy", () => {
     const reporter = new ConsoleActionReporter();
     await copy({
       reporter,
-      destination: destinationPath,
+      output: outputPath,
       rootPath,
       waitForListeners: true,
     });
@@ -89,11 +89,11 @@ describe("copy", () => {
     expect(reporter.errorCount).toBe(0);
     const sourceList = await System.fs.readdir(rootPath);
     expect(sourceList).toStrictEqual(["test.bin", "test.sh"]);
-    const destinationList = await System.fs.readdir(destinationPath);
-    expect(destinationList).toStrictEqual(sourceList);
+    const outputList = await System.fs.readdir(outputPath);
+    expect(outputList).toStrictEqual(sourceList);
     const modes = [
-      await System.fs.stat(Path.join(destinationPath, "test.bin")),
-      await System.fs.stat(Path.join(destinationPath, "test.sh")),
+      await System.fs.stat(Path.join(outputPath, "test.bin")),
+      await System.fs.stat(Path.join(outputPath, "test.sh")),
     ].map(({ mode }) => mode);
     expect(modes).toStrictEqual([0o100755, 0o100755]);
   });

--- a/src/bluehawk/actions/copy.ts
+++ b/src/bluehawk/actions/copy.ts
@@ -7,7 +7,7 @@ import { System } from "../../bluehawk/io/System";
 
 export interface CopyArgs extends ActionArgs {
   rootPath: string;
-  destination: string;
+  output: string;
   state?: string;
   ignore?: string | string[];
 
@@ -20,7 +20,7 @@ export interface CopyArgs extends ActionArgs {
 export const copy = async (
   args: WithActionReporter<CopyArgs>
 ): Promise<void> => {
-  const { destination, ignore, rootPath, waitForListeners, reporter } = args;
+  const { output, ignore, rootPath, waitForListeners, reporter } = args;
   const desiredState = args.state;
   const bluehawk = await getBluehawk();
   let stats: Stats;
@@ -40,7 +40,7 @@ export const copy = async (
   const onBinaryFile = async (filePath: string) => {
     // Copy binary files directly
     const directory = path.join(
-      destination,
+      output,
       path.relative(projectDirectory, path.dirname(filePath))
     );
     const targetPath = path.join(directory, path.basename(filePath));
@@ -51,11 +51,11 @@ export const copy = async (
       reporter.onFileWritten({
         type: "binary",
         sourcePath: filePath,
-        destinationPath: targetPath,
+        outputPath: targetPath,
       });
     } catch (error) {
       reporter.onWriteFailed({
-        destinationPath: targetPath,
+        outputPath: targetPath,
         sourcePath: filePath,
         error,
         type: "binary",
@@ -103,7 +103,7 @@ export const copy = async (
 
     // Use the same relative path
     const directory = path.join(
-      destination,
+      output,
       path.relative(projectDirectory, path.dirname(document.path))
     );
     const targetPath = path.join(directory, document.basename);
@@ -118,11 +118,11 @@ export const copy = async (
       reporter.onFileWritten({
         type: "text",
         sourcePath: document.path,
-        destinationPath: targetPath,
+        outputPath: targetPath,
       });
     } catch (error) {
       reporter.onWriteFailed({
-        destinationPath: targetPath,
+        outputPath: targetPath,
         sourcePath: parseResult.source.path,
         error,
         type: "text",

--- a/src/bluehawk/actions/snip.test.ts
+++ b/src/bluehawk/actions/snip.test.ts
@@ -11,13 +11,13 @@ describe("snip", () => {
 
   it("generates correct RST snippets AND docusaurus snippets", async (done) => {
     const rootPath = Path.resolve("/path/to/project");
-    const destinationPath = "/destination";
+    const outputPath = "/output";
     const testFileName = "test.js";
 
     await System.fs.mkdir(rootPath, {
       recursive: true,
     });
-    await System.fs.mkdir(destinationPath, {
+    await System.fs.mkdir(outputPath, {
       recursive: true,
     });
     await System.fs.writeFile(
@@ -42,22 +42,22 @@ describe("snip", () => {
     await snip({
       reporter,
       paths: [rootPath],
-      destination: destinationPath,
+      output: outputPath,
       state: undefined,
       ignore: undefined,
       format: ["rst", "docusaurus"],
       waitForListeners: true,
     });
 
-    const destinationList = await System.fs.readdir(destinationPath);
-    expect(destinationList).toStrictEqual([
+    const outputList = await System.fs.readdir(outputPath);
+    expect(outputList).toStrictEqual([
       "test.codeblock.foo.js",
       "test.codeblock.foo.js.code-block.md",
       "test.codeblock.foo.js.code-block.rst",
     ]);
 
     const rstFileContents = await System.fs.readFile(
-      Path.join(destinationPath, "test.codeblock.foo.js.code-block.rst"),
+      Path.join(outputPath, "test.codeblock.foo.js.code-block.rst"),
       "utf8"
     );
     expect(rstFileContents).toStrictEqual(`.. code-block:: javascript
@@ -73,7 +73,7 @@ describe("snip", () => {
 `);
 
     const mdFileContents = await System.fs.readFile(
-      Path.join(destinationPath, "test.codeblock.foo.js.code-block.md"),
+      Path.join(outputPath, "test.codeblock.foo.js.code-block.md"),
       "utf8"
     );
     expect(mdFileContents).toStrictEqual(`const bar = "foo"
@@ -91,13 +91,13 @@ console.log(bar);
 
   it("generates correct docusarus-formatted code blocks for start and end blocks at the beginning and end of the block", async (done) => {
     const rootPath = Path.resolve("/path/to/project");
-    const destinationPath = "/destination";
+    const outputPath = "/output";
     const testFileName = "test.js";
 
     await System.fs.mkdir(rootPath, {
       recursive: true,
     });
-    await System.fs.mkdir(destinationPath, {
+    await System.fs.mkdir(outputPath, {
       recursive: true,
     });
     await System.fs.writeFile(
@@ -122,21 +122,21 @@ console.log(bar);
     await snip({
       reporter,
       paths: [rootPath],
-      destination: destinationPath,
+      output: outputPath,
       state: undefined,
       ignore: undefined,
       format: "docusaurus",
       waitForListeners: true,
     });
 
-    const destinationList = await System.fs.readdir(destinationPath);
-    expect(destinationList).toStrictEqual([
+    const outputList = await System.fs.readdir(outputPath);
+    expect(outputList).toStrictEqual([
       "test.codeblock.foo.js",
       "test.codeblock.foo.js.code-block.md",
     ]);
 
     const fileContents = await System.fs.readFile(
-      Path.join(destinationPath, "test.codeblock.foo.js.code-block.md"),
+      Path.join(outputPath, "test.codeblock.foo.js.code-block.md"),
       "utf8"
     );
     expect(fileContents).toStrictEqual(`// highlight-start
@@ -154,13 +154,13 @@ console.log(bar);
 
   it("correctly logics multiple ranges within RST snippets", async () => {
     const rootPath = Path.resolve("/path/to/project");
-    const destinationPath = "/destinationB";
+    const outputPath = "/outputB";
     const testFileName = "test.js";
 
     await System.fs.mkdir(rootPath, {
       recursive: true,
     });
-    await System.fs.mkdir(destinationPath, {
+    await System.fs.mkdir(outputPath, {
       recursive: true,
     });
     await System.fs.writeFile(
@@ -189,20 +189,20 @@ line 9
     await snip({
       reporter,
       paths: [rootPath],
-      destination: destinationPath,
+      output: outputPath,
       state: undefined,
       ignore: undefined,
       format: "rst",
       waitForListeners: true,
     });
-    const destinationList = await System.fs.readdir(destinationPath);
-    expect(destinationList).toStrictEqual([
+    const outputList = await System.fs.readdir(outputPath);
+    expect(outputList).toStrictEqual([
       "test.codeblock.foo.js",
       "test.codeblock.foo.js.code-block.rst",
     ]);
 
     const fileContents = await System.fs.readFile(
-      Path.join(destinationPath, "test.codeblock.foo.js.code-block.rst"),
+      Path.join(outputPath, "test.codeblock.foo.js.code-block.rst"),
       "utf8"
     );
     expect(fileContents).toStrictEqual(`.. code-block:: javascript
@@ -222,13 +222,13 @@ line 9
 
   it("correctly logics multiple ranges within Docusaurus snippets", async () => {
     const rootPath = Path.resolve("/path/to/project");
-    const destinationPath = "/destinationB";
+    const outputPath = "/outputB";
     const testFileName = "test.js";
 
     await System.fs.mkdir(rootPath, {
       recursive: true,
     });
-    await System.fs.mkdir(destinationPath, {
+    await System.fs.mkdir(outputPath, {
       recursive: true,
     });
     await System.fs.writeFile(
@@ -257,21 +257,21 @@ line 9
     await snip({
       reporter,
       paths: [rootPath],
-      destination: destinationPath,
+      output: outputPath,
       state: undefined,
       ignore: undefined,
       format: "docusaurus",
       waitForListeners: true,
     });
 
-    const destinationList = await System.fs.readdir(destinationPath);
-    expect(destinationList).toStrictEqual([
+    const outputList = await System.fs.readdir(outputPath);
+    expect(outputList).toStrictEqual([
       "test.codeblock.foo.js",
       "test.codeblock.foo.js.code-block.md",
     ]);
 
     const fileContents = await System.fs.readFile(
-      Path.join(destinationPath, "test.codeblock.foo.js.code-block.md"),
+      Path.join(outputPath, "test.codeblock.foo.js.code-block.md"),
       "utf8"
     );
     expect(fileContents).toStrictEqual(`line 1
@@ -307,13 +307,13 @@ line 9
 
 `;
     const rootPath = "/path/to/project";
-    const destinationPath = "/carriageReturns";
+    const outputPath = "/carriageReturns";
     const testFileName = "test.js";
 
     await System.fs.mkdir(rootPath, {
       recursive: true,
     });
-    await System.fs.mkdir(destinationPath, {
+    await System.fs.mkdir(outputPath, {
       recursive: true,
     });
     await System.fs.writeFile(Path.join(rootPath, testFileName), text, "utf8");
@@ -321,15 +321,15 @@ line 9
     await snip({
       reporter,
       paths: [rootPath],
-      destination: destinationPath,
+      output: outputPath,
       waitForListeners: true,
     });
 
-    const destinationList = await System.fs.readdir(destinationPath);
-    expect(destinationList).toStrictEqual(["test.codeblock.foo.js"]);
+    const outputList = await System.fs.readdir(outputPath);
+    expect(outputList).toStrictEqual(["test.codeblock.foo.js"]);
 
     const fileContents = await System.fs.readFile(
-      Path.join(destinationPath, "test.codeblock.foo.js"),
+      Path.join(outputPath, "test.codeblock.foo.js"),
       "utf8"
     );
     expect(JSON.stringify(fileContents)).toStrictEqual(
@@ -375,17 +375,17 @@ struct ContentView: SwiftUI.App {
 // :code-block-end:
 `;
     const rootPath = "/path/to/project";
-    const destinationPathSync = "/stateAndEmphasize/sync";
-    const destinationPathLocal = "/stateAndEmphasize/local";
+    const outputPathSync = "/stateAndEmphasize/sync";
+    const outputPathLocal = "/stateAndEmphasize/local";
     const testFileName = "test.swift";
 
     await System.fs.mkdir(rootPath, {
       recursive: true,
     });
-    await System.fs.mkdir(destinationPathSync, {
+    await System.fs.mkdir(outputPathSync, {
       recursive: true,
     });
-    await System.fs.mkdir(destinationPathLocal, {
+    await System.fs.mkdir(outputPathLocal, {
       recursive: true,
     });
     await System.fs.writeFile(Path.join(rootPath, testFileName), text, "utf8");
@@ -393,20 +393,20 @@ struct ContentView: SwiftUI.App {
     await snip({
       reporter,
       paths: [rootPath],
-      destination: destinationPathSync,
+      output: outputPathSync,
       format: "rst",
       state: "sync",
     });
     await snip({
       reporter,
       paths: [rootPath],
-      destination: destinationPathLocal,
+      output: outputPathLocal,
       format: "rst",
       state: "local",
     });
 
     let fileContentsSync = await System.fs.readFile(
-      Path.join(destinationPathSync, "test.codeblock.content-view.swift"),
+      Path.join(outputPathSync, "test.codeblock.content-view.swift"),
       "utf8"
     );
     // Verify states are working in non-rst version
@@ -430,7 +430,7 @@ struct ContentView: SwiftUI.App {
     // Now check states for rst version
     fileContentsSync = await System.fs.readFile(
       Path.join(
-        destinationPathSync,
+        outputPathSync,
         "test.codeblock.content-view.swift.code-block.rst"
       ),
       "utf8"
@@ -458,7 +458,7 @@ struct ContentView: SwiftUI.App {
 
     const fileContentsLocal = await System.fs.readFile(
       Path.join(
-        destinationPathLocal,
+        outputPathLocal,
         "test.codeblock.content-view.swift.code-block.rst"
       ),
       "utf8"
@@ -499,13 +499,13 @@ struct ContentView: SwiftUI.App {
     const rootPath = "/path/to/project";
     const snippetName1 = `test.codeblock.${snippet_1}.js`;
     const snippetName2 = `test.codeblock.${snippet_2}.js`;
-    const destinationPathLocal = "/stateAndEmphasize/local";
+    const outputPathLocal = "/stateAndEmphasize/local";
     const testFileName = "test.js";
 
     await System.fs.mkdir(rootPath, {
       recursive: true,
     });
-    await System.fs.mkdir(destinationPathLocal, {
+    await System.fs.mkdir(outputPathLocal, {
       recursive: true,
     });
     await System.fs.writeFile(Path.join(rootPath, testFileName), text, "utf8");
@@ -513,20 +513,20 @@ struct ContentView: SwiftUI.App {
     await snip({
       reporter,
       paths: [rootPath],
-      destination: destinationPathLocal,
+      output: outputPathLocal,
       id: [snippet_1, snippet_2],
     });
 
     const fileContents1Sync = await System.fs.readFile(
-      Path.join(destinationPathLocal, snippetName1),
+      Path.join(outputPathLocal, snippetName1),
       "utf8"
     );
     const fileContents2Sync = await System.fs.readFile(
-      Path.join(destinationPathLocal, snippetName2),
+      Path.join(outputPathLocal, snippetName2),
       "utf8"
     );
 
-    const allFilesInDest = await System.fs.readdir(destinationPathLocal);
+    const allFilesInDest = await System.fs.readdir(outputPathLocal);
     // Verify that only the snippet with the requested ID was produced
     expect(allFilesInDest).toStrictEqual([snippetName1, snippetName2]);
     // Verify that the contents of the requested snippet is correct

--- a/src/bluehawk/options.ts
+++ b/src/bluehawk/options.ts
@@ -13,11 +13,11 @@ function option<T, K extends string, O extends Options & { once?: boolean }>(
   });
 }
 
-export function withDestinationOption<T>(
+export function withOutputOption<T>(
   yargs: Argv<T>
-): Argv<T & { destination: string }> {
-  return option(yargs, "destination", {
-    alias: "d",
+): Argv<T & { output: string }> {
+  return option(yargs, "output", {
+    alias: "o",
     string: true,
     describe: "the output directory",
     required: true,

--- a/src/cli/commandModules/copy.ts
+++ b/src/cli/commandModules/copy.ts
@@ -1,7 +1,7 @@
 import { ConsoleActionReporter } from "./../../bluehawk/actions/ConsoleActionReporter";
 import { CommandModule, Arguments, Argv } from "yargs";
 import {
-  withDestinationOption,
+  withOutputOption,
   withStateOption,
   withIgnoreOption,
   withLogLevelOption,
@@ -17,7 +17,7 @@ const commandModule: CommandModule<
   command: "copy <rootPath>",
   builder: (yargs): Argv<CopyArgs> => {
     return withLogLevelOption(
-      withIgnoreOption(withStateOption(withDestinationOption(yargs)))
+      withIgnoreOption(withStateOption(withOutputOption(yargs)))
     );
   },
   handler: async (args: Arguments<CopyArgs>) => {
@@ -28,7 +28,7 @@ const commandModule: CommandModule<
   },
   aliases: [],
   describe:
-    "clone source project to destination with Bluehawk commands processed",
+    "clone source project to output directory with Bluehawk commands processed",
 };
 
 export default commandModule;

--- a/src/cli/commandModules/snip.ts
+++ b/src/cli/commandModules/snip.ts
@@ -1,7 +1,7 @@
 import { ConsoleActionReporter } from "./../../bluehawk/actions/ConsoleActionReporter";
 import { CommandModule, Arguments, Argv } from "yargs";
 import {
-  withDestinationOption,
+  withOutputOption,
   withStateOption,
   withIdOption,
   withIgnoreOption,
@@ -18,9 +18,7 @@ const commandModule: CommandModule<ActionArgs & { paths: string[] }, SnipArgs> =
         withIgnoreOption(
           withStateOption(
             withIdOption(
-              withDestinationOption(
-                withGenerateFormattedCodeSnippetsOption(yargs)
-              )
+              withOutputOption(withGenerateFormattedCodeSnippetsOption(yargs))
             )
           )
         )


### PR DESCRIPTION
changed the CLI to use flag `--output/-o` to specify the output directory. updated documentation accordingly as well. 

also updated `CONTRIBUTING.md` to correctly reflect the path to run the local version. 