### PR TITLE
replace `source` with `input` as relevant

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ npm run build
 If compilation is successful, you can run bluehawk like so:
 
 ```sh
-node build/src/main.js snip -o <output directory> <folder to source file or directory>
+node build/src/main.js snip -o <output directory> <folder to input file or directory>
 ```
 
 Which you can alias as:
@@ -58,8 +58,8 @@ Bluehawk has three major components:
   decide what to do with results (e.g. save to file). Can add custom tags
   and language specifications (i.e. comment syntax). The main client is the CLI,
   but you can use Bluehawk as a library and implement your own clients.
-- **Parser:** finds tags in a source file and diagnoses markup errors.
-- **Processor:** executes tags on a source file to produce transformed documents.
+- **Parser:** finds tags in a input file and diagnoses markup errors.
+- **Processor:** executes tags on a input file to produce transformed documents.
 
 ## File Language-Specific Tokens
 

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -19,7 +19,7 @@ bluehawk snip --output <output-directory> <input-directory-or-file>
 
 Output "snippet files" that contain only the content of `code-block` or
 `snippet` Bluehawk tags, named in the format
-`<source-file-name>.codeblock.<codeblock-name>.<source-file-extension>`.
+`<input-file-name>.codeblock.<codeblock-name>.<input-file-extension>`.
 By default, this command generates snippets
 that omit all `state` tag contents. However,
 you can use the `--state` flag to generate snippet files that include

--- a/docs/docs/plugins.md
+++ b/docs/docs/plugins.md
@@ -30,7 +30,7 @@ exports.register = (bluehawk) => {
 Usage:
 
 ```shell
-bluehawk --plugin ./myPlugin source.txt
+bluehawk --plugin ./myPlugin input.txt
 ```
 
 You can pass the --plugin flag multiple times to load different plugins or create a plugin that is composed of other plugins.

--- a/docs/docs/use-cases.md
+++ b/docs/docs/use-cases.md
@@ -9,7 +9,7 @@ custom_edit_url: null
 ### Tested Code Examples
 
 Imagine you want to paste some code from a unit test into your docs. You can
-mark up the unit test source file like this with Bluehawk tags like
+mark up the unit test input file like this with Bluehawk tags like
 `:snippet-start:`, `:snippet-end:`, `:remove-start:`, and `:remove-end:`:
 
 ```swift

--- a/src/bluehawk/BluehawkError.ts
+++ b/src/bluehawk/BluehawkError.ts
@@ -4,5 +4,5 @@ export interface BluehawkError {
   component: "lexer" | "parser" | "visitor" | "validator" | "processor";
   message: string;
   location: Location;
-  sourcePath?: string;
+  inputPath?: string;
 }

--- a/src/bluehawk/Document.ts
+++ b/src/bluehawk/Document.ts
@@ -41,7 +41,7 @@ export class Document {
   readonly id: string;
 
   /**
-    The source text as a conveniently editable magic string. See
+    The input text as a conveniently editable magic string. See
     https://www.npmjs.com/package/magic-string for details.
    */
   text: MagicString;

--- a/src/bluehawk/actions/ActionReporter.ts
+++ b/src/bluehawk/actions/ActionReporter.ts
@@ -45,7 +45,7 @@ export enum LogLevel {
 }
 
 export type FileEvent = {
-  sourcePath: string;
+  inputPath: string;
 };
 
 export type BinaryFileEvent = FileEvent;

--- a/src/bluehawk/actions/ConsoleActionReporter.test.ts
+++ b/src/bluehawk/actions/ConsoleActionReporter.test.ts
@@ -4,27 +4,27 @@ import { ConsoleActionReporter } from "./ConsoleActionReporter";
 
 const dummyReport = (reporter: ActionReporter) => {
   reporter.onBinaryFile({
-    sourcePath: "test",
+    inputPath: "test",
   });
   reporter.onBluehawkErrors({
-    sourcePath: "test",
+    inputPath: "test",
     errors: [],
   });
   reporter.onFileError({
-    sourcePath: "test",
+    inputPath: "test",
     error: new Error(),
   });
   reporter.onFileParsed({
-    sourcePath: "foo",
+    inputPath: "foo",
     parseResult: {
       errors: [],
-      source: {} as Document,
+      input: {} as Document,
       tagNodes: [],
     },
   });
   reporter.onFileWritten({
     outputPath: "foo",
-    sourcePath: "bar",
+    inputPath: "bar",
     type: "text",
   });
   reporter.onIdsUnused({
@@ -33,7 +33,7 @@ const dummyReport = (reporter: ActionReporter) => {
   });
   reporter.onParserNotFound({
     error: new Error(),
-    sourcePath: "test",
+    inputPath: "test",
   });
   reporter.onStateNotFound({
     paths: [],
@@ -47,7 +47,7 @@ const dummyReport = (reporter: ActionReporter) => {
   reporter.onWriteFailed({
     type: "text",
     outputPath: "foo",
-    sourcePath: "bar",
+    inputPath: "bar",
     error: new Error(),
   });
 };

--- a/src/bluehawk/actions/ConsoleActionReporter.ts
+++ b/src/bluehawk/actions/ConsoleActionReporter.ts
@@ -36,20 +36,20 @@ export class ConsoleActionReporter implements ActionReporter {
   onBinaryFile(event: FileEvent): void {
     ++this._count.binaryFiles;
     if (this.logLevel >= LogLevel.Info) {
-      console.log(`found binary file: ${event.sourcePath}`);
+      console.log(`found binary file: ${event.inputPath}`);
     }
   }
   onFileParsed(event: FileParsedEvent): void {
     ++this._count.textFiles;
     if (this.logLevel >= LogLevel.Info) {
-      console.log(`parsed file: ${event.sourcePath}`);
+      console.log(`parsed file: ${event.inputPath}`);
     }
   }
   onFileWritten(event: FileWrittenEvent): void {
     ++this._count.filesWritten;
     if (this.logLevel >= LogLevel.Info) {
       console.log(
-        `wrote ${event.type} file based on ${event.sourcePath} -> ${event.outputPath}`
+        `wrote ${event.type} file based on ${event.inputPath} -> ${event.outputPath}`
       );
     }
   }
@@ -71,21 +71,21 @@ export class ConsoleActionReporter implements ActionReporter {
   onParserNotFound(event: ParserNotFoundEvent): void {
     if (this.logLevel >= LogLevel.Warning) {
       console.warn(
-        `parser not found for file ${event.sourcePath}: ${event.error.message}`
+        `parser not found for file ${event.inputPath}: ${event.error.message}`
       );
     }
   }
   onFileError(event: FileErrorEvent): void {
     ++this._count.errors;
     if (this.logLevel >= LogLevel.Error) {
-      console.error(`file error: ${event.sourcePath}: ${event.error.message}`);
+      console.error(`file error: ${event.inputPath}: ${event.error.message}`);
     }
   }
   onWriteFailed(event: WriteFailedEvent): void {
     ++this._count.errors;
     if (this.logLevel >= LogLevel.Error) {
       console.error(
-        `failed to write file ${event.sourcePath} -> ${event.outputPath}: ${event.error.message}`
+        `failed to write file ${event.inputPath} -> ${event.outputPath}: ${event.error.message}`
       );
     }
   }
@@ -94,7 +94,7 @@ export class ConsoleActionReporter implements ActionReporter {
     this._count.errors += event.errors.length;
     if (this.logLevel >= LogLevel.Error) {
       console.error(
-        `bluehawk errors on ${event.sourcePath}:\n${event.errors
+        `bluehawk errors on ${event.inputPath}:\n${event.errors
           .map((error) => {
             return `(${error.component}) Line ${error.location.line}:${error.location.column} - ${error.message}`;
           })

--- a/src/bluehawk/actions/check.ts
+++ b/src/bluehawk/actions/check.ts
@@ -22,7 +22,7 @@ export const check = async (
   const addErrors = (filePath: string, errors: BluehawkError[]) => {
     reporter.onBluehawkErrors({
       errors,
-      sourcePath: filePath,
+      inputPath: filePath,
     });
     const existingErrors = fileToErrorMap.get(filePath) ?? [];
     fileToErrorMap.set(filePath, [...existingErrors, ...errors]);
@@ -30,13 +30,13 @@ export const check = async (
 
   // Define the handler for generating snippet files.
   bluehawk.subscribe(({ parseResult }) => {
-    const { errors, source } = parseResult;
+    const { errors, input } = parseResult;
     if (errors.length !== 0) {
-      addErrors(source.path, errors);
+      addErrors(input.path, errors);
     }
   });
 
-  // Run through all given source paths and process them.
+  // Run through all given input paths and process them.
   await bluehawk.parseAndProcess(paths, {
     ignore,
     onErrors: addErrors,

--- a/src/bluehawk/actions/copy.test.ts
+++ b/src/bluehawk/actions/copy.test.ts
@@ -26,10 +26,10 @@ describe("copy", () => {
     });
 
     expect(reporter.errorCount).toBe(0);
-    const sourceList = await System.fs.readdir(rootPath);
-    expect(sourceList).toStrictEqual(["test.txt"]);
+    const inputList = await System.fs.readdir(rootPath);
+    expect(inputList).toStrictEqual(["test.txt"]);
     const outputList = await System.fs.readdir(outputPath);
-    expect(outputList).toStrictEqual(sourceList);
+    expect(outputList).toStrictEqual(inputList);
   });
 
   it("copies binary files", async () => {
@@ -56,10 +56,10 @@ describe("copy", () => {
     });
 
     expect(reporter.errorCount).toBe(0);
-    const sourceList = await System.fs.readdir(rootPath);
-    expect(sourceList).toStrictEqual(["test.bin"]);
+    const inputList = await System.fs.readdir(rootPath);
+    expect(inputList).toStrictEqual(["test.bin"]);
     const outputList = await System.fs.readdir(outputPath);
-    expect(outputList).toStrictEqual(sourceList);
+    expect(outputList).toStrictEqual(inputList);
     expect(didCallBinaryFileForPath).toBe(filePath);
   });
 
@@ -87,10 +87,10 @@ describe("copy", () => {
     });
 
     expect(reporter.errorCount).toBe(0);
-    const sourceList = await System.fs.readdir(rootPath);
-    expect(sourceList).toStrictEqual(["test.bin", "test.sh"]);
+    const inputList = await System.fs.readdir(rootPath);
+    expect(inputList).toStrictEqual(["test.bin", "test.sh"]);
     const outputList = await System.fs.readdir(outputPath);
-    expect(outputList).toStrictEqual(sourceList);
+    expect(outputList).toStrictEqual(inputList);
     const modes = [
       await System.fs.stat(Path.join(outputPath, "test.bin")),
       await System.fs.stat(Path.join(outputPath, "test.sh")),

--- a/src/bluehawk/actions/copy.ts
+++ b/src/bluehawk/actions/copy.ts
@@ -29,7 +29,7 @@ export const copy = async (
   } catch (error) {
     reporter.onFileError({
       error,
-      sourcePath: rootPath,
+      inputPath: rootPath,
     });
     return;
   }
@@ -50,13 +50,13 @@ export const copy = async (
       await copyPermissions({ to: targetPath, from: filePath });
       reporter.onFileWritten({
         type: "binary",
-        sourcePath: filePath,
+        inputPath: filePath,
         outputPath: targetPath,
       });
     } catch (error) {
       reporter.onWriteFailed({
         outputPath: targetPath,
-        sourcePath: filePath,
+        inputPath: filePath,
         error,
         type: "binary",
       });
@@ -117,13 +117,13 @@ export const copy = async (
       });
       reporter.onFileWritten({
         type: "text",
-        sourcePath: document.path,
+        inputPath: document.path,
         outputPath: targetPath,
       });
     } catch (error) {
       reporter.onWriteFailed({
         outputPath: targetPath,
-        sourcePath: parseResult.source.path,
+        inputPath: parseResult.input.path,
         error,
         type: "text",
       });
@@ -134,10 +134,10 @@ export const copy = async (
     ignore,
     onBinaryFile,
     waitForListeners: waitForListeners ?? false,
-    onErrors(sourcePath, errors) {
+    onErrors(inputPath, errors) {
       reporter.onBluehawkErrors({
         errors,
-        sourcePath,
+        inputPath,
       });
     },
     reporter,

--- a/src/bluehawk/actions/snip.ts
+++ b/src/bluehawk/actions/snip.ts
@@ -1,6 +1,6 @@
 import { WithActionReporter, ActionReporter } from "./ActionReporter";
 import * as path from "path";
-import { getBluehawk, EmphasizeSourceAttributes } from "../../bluehawk";
+import { getBluehawk, EmphasizeInputAttributes } from "../../bluehawk";
 import { System } from "../../bluehawk/io/System";
 import { ActionArgs } from "./ActionArgs";
 import { ProcessResult } from "../../bluehawk/processor/Processor";
@@ -37,7 +37,7 @@ export const createFormattedCodeBlock = async ({
 
     reporter.onFileWritten({
       type: "text",
-      sourcePath: document.path,
+      inputPath: document.path,
       outputPath: targetPath,
     });
   } else if (format === "docusaurus") {
@@ -48,7 +48,7 @@ export const createFormattedCodeBlock = async ({
     await System.fs.writeFile(targetPath, formattedCodeblock, "utf8");
     reporter.onFileWritten({
       type: "text",
-      sourcePath: document.path,
+      inputPath: document.path,
       outputPath: targetPath,
     });
   } // add additional elses + "formatInLanguage" methods to handle other markup languages
@@ -64,7 +64,7 @@ export const formatInRst = async (
 
   const emphasizeAttributes = document.attributes[
     "emphasize"
-  ] as EmphasizeSourceAttributes;
+  ] as EmphasizeInputAttributes;
 
   // nasty hack to cover the suffixes/rst languages we use most often
   // TODO: switch to a better mapping
@@ -133,7 +133,7 @@ export const formatInDocusaurus = async (
   // get the list of emphasize ranges, converting individual emphasize lines to ranges for simplicity
   const emphasizeAttributes = document.attributes[
     "emphasize"
-  ] as EmphasizeSourceAttributes;
+  ] as EmphasizeInputAttributes;
   const emphasizeRanges: { start: number; end: number }[] = [];
   if (emphasizeAttributes !== undefined) {
     for (const range of emphasizeAttributes.ranges) {
@@ -222,7 +222,7 @@ export const snip = async (
       await System.fs.writeFile(targetPath, document.text.toString(), "utf8");
       reporter.onFileWritten({
         type: "text",
-        sourcePath: document.path,
+        inputPath: document.path,
         outputPath: targetPath,
       });
 
@@ -241,7 +241,7 @@ export const snip = async (
       reporter.onWriteFailed({
         type: "text",
         outputPath: targetPath,
-        sourcePath: parseResult.source.path,
+        inputPath: parseResult.input.path,
         error,
       });
     }
@@ -251,9 +251,9 @@ export const snip = async (
     reporter,
     ignore,
     waitForListeners: waitForListeners ?? false,
-    onErrors(sourcePath, errors) {
+    onErrors(inputPath, errors) {
       reporter.onBluehawkErrors({
-        sourcePath,
+        inputPath,
         errors,
       });
     },

--- a/src/bluehawk/parser/ParseResult.ts
+++ b/src/bluehawk/parser/ParseResult.ts
@@ -6,6 +6,6 @@ import { LanguageSpecification } from "./LanguageSpecification";
 export interface ParseResult {
   errors: BluehawkError[];
   tagNodes: AnyTagNode[];
-  source: Document;
+  input: Document;
   languageSpecification?: LanguageSpecification;
 }

--- a/src/bluehawk/parser/makeParser.ts
+++ b/src/bluehawk/parser/makeParser.ts
@@ -13,7 +13,7 @@ import { makeCstVisitor } from "./visitor";
 // Complete parser (lexicon, syntax, and semantics).
 export interface IParser {
   languageSpecification: LanguageSpecification;
-  parse(source: Document): ParseResult;
+  parse(input: Document): ParseResult;
 }
 
 // Token patterns are required to be sticky (y flag)
@@ -58,23 +58,23 @@ export function makeParser(
   const syntaxProcessor = new RootParser(languageTokens);
   const semanticsProcessor = makeCstVisitor(syntaxProcessor);
   return {
-    parse(source: Document) {
+    parse(input: Document) {
       // ⚠️ Caller is responsible for making sure this parser is appropriate for
-      // the source language
-      const parseResult = syntaxProcessor.parse(source.text.original);
+      // the input language
+      const parseResult = syntaxProcessor.parse(input.text.original);
       if (parseResult.cst === undefined) {
         return {
           tagNodes: [],
           errors: parseResult.errors,
-          source,
+          input,
           languageSpecification,
         };
       }
-      const visitorResult = semanticsProcessor.visit(parseResult.cst, source);
+      const visitorResult = semanticsProcessor.visit(parseResult.cst, input);
       return {
         errors: [...parseResult.errors, ...visitorResult.errors],
         tagNodes: visitorResult.tagNodes,
-        source,
+        input,
         languageSpecification,
       };
     },

--- a/src/bluehawk/parser/visitor/jsonAttributeList.test.ts
+++ b/src/bluehawk/parser/visitor/jsonAttributeList.test.ts
@@ -10,7 +10,7 @@ describe("JSON attribute lists", () => {
     makeLineCommentToken(/\/\//),
   ]);
   const { lexer } = parser;
-  const source = new Document({
+  const input = new Document({
     text: "mock",
     path: "mock",
   });
@@ -24,7 +24,7 @@ describe("JSON attribute lists", () => {
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes[0].tagName).toBe("A-tag");
     expect(result.tagNodes[0].attributes).toStrictEqual({});
@@ -48,7 +48,7 @@ describe("JSON attribute lists", () => {
     const cst = parser.annotatedText();
     expect(parser.errors.length).toBe(0);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes[0].tagName).toBe("A-tag");
     expect(result.tagNodes[0].attributes).toStrictEqual({
@@ -81,7 +81,7 @@ describe("JSON attribute lists", () => {
     const cst = parser.annotatedText();
     expect(parser.errors.length).toBe(0);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.tagNodes[0].attributes).toBeUndefined();
     expect(result.errors[0].message).toBe("Unexpected number in JSON");
     expect(result.errors[0].location).toStrictEqual({
@@ -104,7 +104,7 @@ describe("JSON attribute lists", () => {
     const cst = parser.annotatedText();
     expect(parser.errors.length).toBe(0);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors[0].location).toStrictEqual({
       line: 5,
       column: 1,
@@ -127,7 +127,7 @@ describe("JSON attribute lists", () => {
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors[0].location).toStrictEqual({
       line: 5,
       column: 1,
@@ -150,7 +150,7 @@ describe("JSON attribute lists", () => {
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors[0].location).toStrictEqual({
       line: 5,
       column: 1,
@@ -175,7 +175,7 @@ describe("JSON attribute lists", () => {
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes[0].attributes).toStrictEqual({
       a: 1,
@@ -197,7 +197,7 @@ describe("JSON attribute lists", () => {
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes[0].attributes).toStrictEqual({
       a: "//",
@@ -217,7 +217,7 @@ describe("JSON attribute lists", () => {
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors[0].location).toStrictEqual({
       line: 3,
       column: 4,

--- a/src/bluehawk/parser/visitor/multilang.test.ts
+++ b/src/bluehawk/parser/visitor/multilang.test.ts
@@ -41,7 +41,7 @@ CC
 });
 
 describe("multilang", () => {
-  const someSource = new Document({
+  const someInput = new Document({
     path: "mock",
     text: "mock",
   });
@@ -77,7 +77,7 @@ describe("multilang", () => {
     if (parseResult.cst === undefined) {
       return;
     }
-    const result = visitor.visit(parseResult.cst, someSource);
+    const result = visitor.visit(parseResult.cst, someInput);
     expect(result.errors).toStrictEqual([]);
     expect(
       result.tagNodes.map((tag) => [tag.tagName, tag.inContext])
@@ -108,7 +108,7 @@ describe("multilang", () => {
     if (parseResult.cst === undefined) {
       return;
     }
-    const result = visitor.visit(parseResult.cst, someSource);
+    const result = visitor.visit(parseResult.cst, someInput);
     expect(result.errors).toStrictEqual([]);
     expect(
       result.tagNodes.map((tag) => [tag.tagName, tag.inContext])
@@ -138,7 +138,7 @@ describe("multilang", () => {
     if (parseResult.cst === undefined) {
       return;
     }
-    const result = visitor.visit(parseResult.cst, someSource);
+    const result = visitor.visit(parseResult.cst, someInput);
     expect(result.errors[0].message).toContain(
       "blockComment: After Newline, expected BlockCommentEnd but found EOF"
     );
@@ -172,7 +172,7 @@ describe("multilang", () => {
     if (parseResult.cst === undefined) {
       return;
     }
-    const result = visitor.visit(parseResult.cst, someSource);
+    const result = visitor.visit(parseResult.cst, someInput);
     expect(result.errors).toStrictEqual([]);
     expect(
       result.tagNodes.map((tag) => [tag.tagName, tag.inContext])

--- a/src/bluehawk/parser/visitor/visitor.test.ts
+++ b/src/bluehawk/parser/visitor/visitor.test.ts
@@ -10,7 +10,7 @@ describe("visitor", () => {
     makeLineCommentToken(/\/\//),
   ]);
   const { lexer } = parser;
-  const source = new Document({
+  const input = new Document({
     text: "mock",
     path: "mock",
   });
@@ -30,7 +30,7 @@ annotated text
     parser.input = tokens.tokens;
     const visitor = makeCstVisitor(parser);
     const cst = parser.annotatedText();
-    visitor.visit(cst, source);
+    visitor.visit(cst, input);
   });
 
   it("supports multiple tags", () => {
@@ -44,7 +44,7 @@ annotated text
     const cst = parser.annotatedText();
     expect(parser.errors.length).toBe(0);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes.length).toBe(3);
     expect(result.tagNodes[0].tagName).toBe("A-tag");
@@ -66,7 +66,7 @@ annotated text
     const cst = parser.annotatedText();
     expect(parser.errors.length).toBe(0);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes.length).toBe(3);
     expect(result.tagNodes[0].tagName).toBe("A-tag");
@@ -84,7 +84,7 @@ annotated text
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors[0].message).toBe(
       "Unexpected this-is-a-different-tag-end closing this-is-a-tag-start"
     );
@@ -107,7 +107,7 @@ annotated text
     const cst = parser.annotatedText();
     expect(parser.errors.length).toBe(0);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes.length).toBe(1);
     expect((result.tagNodes[0].children ?? []).length).toBe(1);
@@ -126,7 +126,7 @@ annotated text
     const cst = parser.annotatedText();
     expect(parser.errors.length).toBe(0);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes[0].tagName).toBe("A");
     expect((result.tagNodes[0].children ?? []).length).toBe(0);
@@ -153,7 +153,7 @@ annotated text
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes[0].tagName).toBe("tag-in-a-block-comment");
     expect(result.tagNodes[0].inContext).toBe("blockComment");
@@ -189,7 +189,7 @@ annotated text
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes[0].tagName).toBe("line-commented-block-tag");
     expect(result.tagNodes[0].inContext).toBe("lineComment");
@@ -214,7 +214,7 @@ annotated text
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes[0].tagName).toBe("not-sure-how-to-test-this");
     expect(result.tagNodes[0].inContext).toBe("none");
@@ -239,7 +239,7 @@ annotated text
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     const a = result.tagNodes[0];
     expect(a.tagName).toBe("a");
@@ -281,7 +281,7 @@ the quick brown fox jumped
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes.length).toBe(1);
     const a = result.tagNodes[0];
@@ -307,7 +307,7 @@ the quick brown fox jumped
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes.length).toBe(1);
     const a = result.tagNodes[0];
@@ -343,7 +343,7 @@ and again
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes.length).toBe(1);
 
@@ -426,7 +426,7 @@ and again
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes[0].tagName).toBe("A-tag");
     expect(result.tagNodes[0].range.start.line).toBe(1);
@@ -453,7 +453,7 @@ and again
     const cst = parser.annotatedText();
     expect(parser.errors.length).toBe(0);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes.length).toBe(3);
     expect(result.tagNodes[0].tagName).toBe("A-tag");
@@ -478,7 +478,7 @@ and again
     const cst = parser.annotatedText();
     expect(parser.errors.length).toBe(0);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes.length).toBe(3);
     expect(result.tagNodes[0].tagName).toBe("A-tag");
@@ -531,7 +531,7 @@ and again
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes.length).toBe(1);
     expect(result.tagNodes[0].contentRange).toBeUndefined();
@@ -555,7 +555,7 @@ line 10 :a-end:
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes.length).toBe(1);
     const lines = tokenString.split("\n");
@@ -594,7 +594,7 @@ line 10 :a-end:
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(
       result.tagNodes[0].lineComments.map((token) => token.startLine)
@@ -618,7 +618,7 @@ c2345678 :a-start:
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     expect(result.errors).toStrictEqual([]);
     expect(result.tagNodes.length).toBe(1);
     // Re-add newlines since they are included in the offset

--- a/src/bluehawk/processor/Processor.test.ts
+++ b/src/bluehawk/processor/Processor.test.ts
@@ -19,13 +19,13 @@ describe("processor", () => {
   it("ignores unknown tags", async (done) => {
     // NOTE: This is not necessarily the desired behavior, but it is the current
     // behavior.
-    const source = new Document({
+    const input = new Document({
       text: `:unknown-tag:
 `,
       path: "test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     expect(parseResult.tagNodes[0].tagName).toBe("unknown-tag");
     const files = await bluehawk.process(parseResult);
     expect(files["test.js"].document.text.toString()).toBe(`:unknown-tag:
@@ -34,13 +34,13 @@ describe("processor", () => {
   });
 
   it("supports async listeners", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `abc\n`,
       path: "test.js",
     });
 
     const bluehawk = new Bluehawk();
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
 
     let didCallListener = 0;
     let didWaitForListener = 0;
@@ -70,13 +70,13 @@ describe("processor", () => {
   });
 
   it("does not stop on misbehaving listeners", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `abc\n`,
       path: "test.js",
     });
 
     const bluehawk = new Bluehawk();
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
 
     let didCallListener = 0;
     let didWaitForListener = 0;

--- a/src/bluehawk/processor/Processor.ts
+++ b/src/bluehawk/processor/Processor.ts
@@ -130,14 +130,14 @@ export class Processor {
     processOptions?: ProcessOptions
   ): Promise<BluehawkFiles> => {
     this._removeMetaRanges(
-      parseResult.source.text,
+      parseResult.input.text,
       parseResult.tagNodes,
       processOptions
     );
     const _processorState = new ProcessorState(parseResult, processOptions);
     await this._fork({
       tagNodes: parseResult.tagNodes,
-      document: parseResult.source,
+      document: parseResult.input,
       _processorState,
     });
     await Promise.allSettled(_processorState.promises);

--- a/src/bluehawk/processor/validator.test.ts
+++ b/src/bluehawk/processor/validator.test.ts
@@ -28,7 +28,7 @@ describe("validator", () => {
     }),
   };
 
-  const source = new Document({
+  const input = new Document({
     path: "",
     text: "",
   });
@@ -50,7 +50,7 @@ the quick brown fox jumped
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     const errors = validateTags(result.tagNodes, {});
     expect(errors.length).toBe(0);
   });
@@ -66,7 +66,7 @@ the quick brown fox jumped
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     const errors = validateTags(result.tagNodes, tagProcessors);
     expect(errors.length).toBe(1);
     expect(errors[0].message).toStrictEqual(
@@ -94,7 +94,7 @@ the quick brown fox jumped
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     const errors = validateTags(result.tagNodes, tagProcessors);
     expect(errors.length).toBe(1);
     expect(errors[0].message).toStrictEqual(
@@ -122,7 +122,7 @@ the quick brown fox jumped
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     const errors = validateTags(result.tagNodes, tagProcessors);
     expect(errors.length).toBe(2);
     expect(errors[0].message).toStrictEqual(
@@ -154,7 +154,7 @@ the quick brown fox jumped
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     const errors = validateTags(result.tagNodes, tagProcessors);
     expect(errors.length).toBe(0);
   });
@@ -174,7 +174,7 @@ the quick brown fox jumped
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     const errors = validateTags(result.tagNodes, tagProcessors);
     expect(errors.length).toBe(1);
     expect(errors[0].message).toStrictEqual(
@@ -202,7 +202,7 @@ the quick brown fox jumped
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     const errors = validateTags(result.tagNodes, tagProcessors);
     expect(errors.length).toBe(1);
     expect(errors[0].message).toStrictEqual(
@@ -230,7 +230,7 @@ the quick brown fox jumped
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     const errors = validateTags(result.tagNodes, tagProcessors);
     expect(errors.length).toBe(0);
   });
@@ -250,7 +250,7 @@ the quick brown fox jumped
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     const errors = validateTags(result.tagNodes, tagProcessors);
     expect(errors.length).toBe(1);
     expect(errors[0].message).toStrictEqual(
@@ -278,7 +278,7 @@ the quick brown fox jumped
     const cst = parser.annotatedText();
     expect(parser.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
-    const result = visitor.visit(cst, source);
+    const result = visitor.visit(cst, input);
     const errors = validateTags(result.tagNodes, tagProcessors);
     expect(errors.length).toBe(1);
     expect(errors[0].message).toStrictEqual(
@@ -320,7 +320,7 @@ the quick brown fox jumped
     expect(parseResult.errors).toStrictEqual([]);
     const visitor = makeCstVisitor(parser);
     assert(parseResult.cst !== undefined);
-    const result = visitor.visit(parseResult.cst, source);
+    const result = visitor.visit(parseResult.cst, input);
     const errors = validateTags(result.tagNodes, tagProcessors);
     expect(errors).toStrictEqual([
       {

--- a/src/bluehawk/project/loadProjectPaths.ts
+++ b/src/bluehawk/project/loadProjectPaths.ts
@@ -51,7 +51,7 @@ async function traverse(
   return (await Promise.all(promises)).flat();
 }
 
-// Given a source entry point path, load all paths to files within, mindful of
+// Given a input entry point path, load all paths to files within, mindful of
 // .gitignore.
 export async function loadProjectPaths(project: Project): Promise<string[]> {
   const projectRoot = path.resolve(project.rootPath);

--- a/src/bluehawk/tags/EmphasizeTag.ts
+++ b/src/bluehawk/tags/EmphasizeTag.ts
@@ -12,7 +12,7 @@ export interface EmphasizeRange {
   };
 }
 
-export interface EmphasizeSourceAttributes {
+export interface EmphasizeInputAttributes {
   ranges: EmphasizeRange[];
 }
 

--- a/src/bluehawk/tags/emphasizeTag.test.ts
+++ b/src/bluehawk/tags/emphasizeTag.test.ts
@@ -13,7 +13,7 @@ describe("emphasize tag", () => {
   });
 
   it("works as a one line tag", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `a
 b // :emphasize:
 c
@@ -21,7 +21,7 @@ c
       path: "test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(files["test.js"].document.text.toString()).toBe(
       `a
@@ -55,12 +55,12 @@ describe("some stuff", () => {
 console.log(bar);
 `;
 
-    const source = new Document({
+    const input = new Document({
       text: singleInput,
       path: "test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(files["test.js"].document.text.toString()).toBe(`const bar = "foo"
 
@@ -100,12 +100,12 @@ describe("some stuff", () => {
 console.log(bar);
 `;
 
-    const source = new Document({
+    const input = new Document({
       text: singleInput,
       path: "test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(files["test.js"].document.text.toString()).toBe(`const bar = "foo"
 
@@ -151,12 +151,12 @@ line 8
 // :emphasize-end:
 line 9`;
 
-    const source = new Document({
+    const input = new Document({
       text: singleInput,
       path: "test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(files["test.js"].document.text.toString()).toBe(`line 1
 line 2

--- a/src/bluehawk/tags/removeMetaRange.test.ts
+++ b/src/bluehawk/tags/removeMetaRange.test.ts
@@ -23,7 +23,7 @@ describe("removeMetaRange", () => {
   it("behaves on block tags", async () => {
     // Note that it completely deletes the line on which the -end tag is
     // found.
-    const source = new Document({
+    const input = new Document({
       text: `const bar = "foo";
 // :strip-this-start: {
 // "a": 1,
@@ -38,7 +38,7 @@ const qux = "baz";
       path: "strip.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(files["strip.test.js"].document.text.toString()).toBe(
       `const bar = "foo";
@@ -50,7 +50,7 @@ const qux = "baz";
     );
   });
   it("behaves on line tags", async () => {
-    const source = new Document({
+    const input = new Document({
       text: `const bar = "foo";
 const baz = "bar"; // :strip-this:
 :strip-this: :not-this:
@@ -59,7 +59,7 @@ const qux = "baz"; // not this :strip-this:
       path: "strip.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(files["strip.test.js"].document.text.toString()).toBe(
       `const bar = "foo";
@@ -71,7 +71,7 @@ const qux = "baz"; // not this
   });
 
   it("behaves with doubled-up line tags", async () => {
-    const source = new Document({
+    const input = new Document({
       text: `abc
 def // :strip-this: :strip-this:
 ghi // :strip-this: // :strip-this:
@@ -80,7 +80,7 @@ jkl //// :strip-this: // :strip-this:
       path: "strip.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(files["strip.test.js"].document.text.toString()).toBe(
       `abc

--- a/src/bluehawk/tags/removeTag.test.ts
+++ b/src/bluehawk/tags/removeTag.test.ts
@@ -53,12 +53,12 @@ describe("some stuff", () => {
 console.log(bar);
 `;
 
-    const source = new Document({
+    const inputFile = new Document({
       text: singleInput,
       path: "test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(inputFile);
     const files = await bluehawk.process(parseResult);
     expect(files["test.js"].document.text.toString()).toBe(`const bar = "foo"
 
@@ -68,7 +68,7 @@ console.log(bar);
   });
 
   it("nests", async (done) => {
-    const source = new Document({
+    const inputFile = new Document({
       text: `a
 :remove-start:
 b
@@ -82,7 +82,7 @@ e
       path: "test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(inputFile);
     const files = await bluehawk.process(parseResult);
     expect(files["test.js"].document.text.toString()).toBe(
       `a
@@ -99,12 +99,12 @@ e
 // :remove-end:
 `;
 
-    const source = new Document({
+    const inputFile = new Document({
       text: input,
       path: "test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(inputFile);
     expect(parseResult.errors[0].message).toStrictEqual(
       "attribute list for 'remove' tag should be null"
     );
@@ -118,12 +118,12 @@ this should also be removed // :remove: // do it
 but not this
 `;
 
-    const source = new Document({
+    const inputFile = new Document({
       text: input,
       path: "test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(inputFile);
     const files = await bluehawk.process(parseResult);
     expect(files["test.js"].document.text.toString()).toBe(
       `leave this

--- a/src/bluehawk/tags/replaceTag.test.ts
+++ b/src/bluehawk/tags/replaceTag.test.ts
@@ -17,35 +17,35 @@ describe("replace tag", () => {
   });
 
   it("errors when no attribute list is given", () => {
-    const source = new Document({
+    const input = new Document({
       text: `// :replace-start:
 // :replace-end:
 `,
       path: "replace.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     expect(parseResult.errors[0].message).toBe(
       "attribute list for 'replace' tag should be object"
     );
   });
 
   it("errors when invalid attribute list is given", () => {
-    const source = new Document({
+    const input = new Document({
       text: `// :replace-start: {"terms":{"numbersNotAllowed": 1}}
 // :replace-end:
 `,
       path: "replace.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     expect(parseResult.errors[0].message).toBe(
       "attribute list for 'replace' tag/terms/numbersNotAllowed should be string"
     );
   });
 
   it("replaces keys with values", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `// :replace-start: {
 // "terms": {
 //   "Replace Me": "It works!",
@@ -59,7 +59,7 @@ and see test2
       path: "replace.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     expect(parseResult.errors).toStrictEqual([]);
     const files = await bluehawk.process(parseResult);
     expect(files["replace.test.js"].document.text.toString())
@@ -71,7 +71,7 @@ and see --replaced--
   });
 
   it("is case sensitive", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `// :replace-start: {"terms": {
 //   "Notice the Case": "It works!",
 //   "UNCHANGED": "changed"
@@ -84,7 +84,7 @@ and see unchanged
       path: "replace.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     expect(parseResult.errors.length).toBe(0);
     const files = await bluehawk.process(parseResult);
     expect(files["replace.test.js"].document.text.toString())
@@ -96,7 +96,7 @@ and see unchanged
   });
 
   it("replaces all instances within the block", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `replaceme
 replaceme
 ---
@@ -118,7 +118,7 @@ replaceme
       path: "replace.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     expect(parseResult.errors.length).toBe(0);
     const files = await bluehawk.process(parseResult);
     expect(files["replace.test.js"].document.text.toString()).toBe(`replaceme
@@ -139,7 +139,7 @@ replaceme
   });
 
   it("can't match outside of its block", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `// :replace-start: {"terms": {
 //   ":replace-": "hacked"
 // }}
@@ -149,7 +149,7 @@ replaceme
       path: "replace.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     expect(parseResult.errors).toStrictEqual([]);
     const files = await bluehawk.process(parseResult);
     expect(files["replace.test.js"].document.text.toString()).toBe(
@@ -159,7 +159,7 @@ replaceme
   });
 
   it("interoperates with remove", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `// :replace-start: {"terms": {
 //   "removethis": ""
 // }}
@@ -176,7 +176,7 @@ andremovethisaswell
       path: "replace.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     expect(parseResult.errors).toStrictEqual([]);
     const files = await bluehawk.process(parseResult);
     expect(files["replace.test.js"].document.text.toString())
@@ -189,7 +189,7 @@ andaswell
   });
 
   it("doesn't unexpectedly use id as a replacement", () => {
-    const source = new Document({
+    const input = new Document({
       text: `// :replace-start: foo
 it's my id
 :replace-end:
@@ -197,14 +197,14 @@ it's my id
       path: "replace.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     expect(parseResult.errors[0].message).toBe(
       "attribute list for 'replace' tag should have required property 'terms'"
     );
   });
 
   it("handles a real-world example", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `// :replace-start: {
 //   "terms": {
 //     "ReadWriteDataExamples_": ""
@@ -269,7 +269,7 @@ class ReadWriteData: XCTestCase {
       path: "replace.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     expect(parseResult.errors.length).toBe(0);
     const files = await bluehawk.process(parseResult);
     expect(files["replace.test.js"].document.text.toString())

--- a/src/bluehawk/tags/snippetTag.test.ts
+++ b/src/bluehawk/tags/snippetTag.test.ts
@@ -19,7 +19,7 @@ describe("snippet Tag", () => {
     expect(true).toBeTruthy();
   });
 });`;
-    const source = new Document({
+    const input = new Document({
       text: `const bar = "foo"
 
 // :snippet-start: foo
@@ -30,7 +30,7 @@ console.log(bar);
       path: "snippet.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(Object.keys(files)).toStrictEqual([
       "snippet.test.js",
@@ -43,7 +43,7 @@ console.log(bar);
   });
 
   it("dedents the snippet", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `const bar = "foo"
     // :snippet-start: foo
      abc
@@ -54,7 +54,7 @@ console.log(bar);
       path: "snippet.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(
       files["snippet.test.codeblock.foo.js"].document.text.toString()
@@ -68,7 +68,7 @@ ghi
   });
 
   it("dedents a realistic snippet", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `        // :snippet-start: delete-collection
         let realm = try! Realm()
         try! realm.write {
@@ -83,7 +83,7 @@ ghi
       path: "snippet.test.swift",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(
       files[
@@ -104,7 +104,7 @@ try! realm.write {
   });
 
   it("handles empty snippets", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `const bar = "foo"
     // :snippet-start: foo
     // :snippet-end:
@@ -112,7 +112,7 @@ try! realm.write {
       path: "snippet.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(
       files["snippet.test.codeblock.foo.js"].document.text.toString()
@@ -121,7 +121,7 @@ try! realm.write {
   });
 
   it("handles adjusted offsets", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `some text
 // :snippet-start: foo
 // :remove-start:
@@ -132,7 +132,7 @@ hide this
       path: "snippet.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(
       files["snippet.test.codeblock.foo.js"].document.text.toString()
@@ -141,7 +141,7 @@ hide this
   });
 
   it("supports nested snippets", async () => {
-    const source = new Document({
+    const input = new Document({
       text: `some text
 // :snippet-start: a
 hello
@@ -154,7 +154,7 @@ world
       path: "snippet.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(files["snippet.test.codeblock.a.js"].document.text.toString()).toBe(
       `hello

--- a/src/bluehawk/tags/stateTag.test.ts
+++ b/src/bluehawk/tags/stateTag.test.ts
@@ -47,7 +47,7 @@ console.log("we are foo");
 end
 `;
     const parseResult = bluehawk.parse(multipleInput);
-    expect(parseResult.source.path).toBe("stateTag.test.js");
+    expect(parseResult.input.path).toBe("stateTag.test.js");
     const files = await bluehawk.process(parseResult);
     // wait what? Two snippets?
     // It's because the snippet lives outside of the states
@@ -99,7 +99,7 @@ console.log("we are foo");
 end
 `;
     const parseResult = bluehawk.parse(multipleInput);
-    expect(parseResult.source.path).toBe("stateTag.test.js");
+    expect(parseResult.input.path).toBe("stateTag.test.js");
     const files = await bluehawk.process(parseResult);
     // wait what? Two snippets?
     // It's because the snippet lives outside of the states
@@ -162,7 +162,7 @@ console.log("we are foo");
 end
 `;
     const parseResult = bluehawk.parse(multipleInput);
-    expect(parseResult.source.path).toBe("stateTag.test.js");
+    expect(parseResult.input.path).toBe("stateTag.test.js");
     const files = await bluehawk.process(parseResult);
     // wait what? Two snippets?
     // It's because the snippet lives outside of the states

--- a/src/bluehawk/tags/uncommentTag.test.ts
+++ b/src/bluehawk/tags/uncommentTag.test.ts
@@ -14,7 +14,7 @@ describe("uncomment tag", () => {
   });
 
   it("uncomments", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `// :uncomment-start:
 //comment
 no comment
@@ -24,7 +24,7 @@ no comment
       path: "uncomment.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(files["uncomment.test.js"].document.text.toString()).toBe(
       `comment
@@ -36,7 +36,7 @@ no comment
   });
 
   it("handles one space after comments", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `// :uncomment-start:
 // comment
 no comment
@@ -46,7 +46,7 @@ no comment
       path: "uncomment.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(files["uncomment.test.js"].document.text.toString()).toBe(
       `comment
@@ -58,7 +58,7 @@ no comment
   });
 
   it("nests", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `// :uncomment-start:
 // comment
 // // :uncomment-start:
@@ -70,7 +70,7 @@ no comment
       path: "uncomment.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(files["uncomment.test.js"].document.text.toString()).toBe(
       `comment
@@ -82,7 +82,7 @@ no comment
   });
 
   it("uncomments only at the beginning of the line (after whitespace if any)", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `// :uncomment-start:
       a//
 leave me alone // comment
@@ -96,7 +96,7 @@ leave this alone // // double comment
       path: "uncomment.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(files["uncomment.test.js"].document.text.toString()).toBe(
       `      a//
@@ -112,7 +112,7 @@ leave this alone // // double comment
   });
 
   it("pairs with remove", async (done) => {
-    const source = new Document({
+    const input = new Document({
       text: `// :uncomment-start:
 // comment
 // :remove-start:
@@ -127,7 +127,7 @@ no comment
       path: "uncomment.test.js",
     });
 
-    const parseResult = bluehawk.parse(source);
+    const parseResult = bluehawk.parse(input);
     const files = await bluehawk.process(parseResult);
     expect(files["uncomment.test.js"].document.text.toString()).toBe(
       `comment

--- a/src/cli/commandModules/copy.ts
+++ b/src/cli/commandModules/copy.ts
@@ -28,7 +28,7 @@ const commandModule: CommandModule<
   },
   aliases: [],
   describe:
-    "clone source project to output directory with Bluehawk commands processed",
+    "clone input project to output directory with Bluehawk commands processed",
 };
 
 export default commandModule;


### PR DESCRIPTION
addressing https://github.com/mongodb-university/Bluehawk/pull/88#discussion_r860259112

changing word `source` to `input` throughout the code/docs to align with the previous change of text from `destination` to `output` in PR #88 

no changes to the external API