### PR TITLE
Add Python as Supported Language

### DIFF
--- a/src/bluehawk/actions/snip.test.ts
+++ b/src/bluehawk/actions/snip.test.ts
@@ -108,7 +108,11 @@ a=1+2
 # :state-start: ${state}
 print("hello world#:remove:")
 print('hello \\'world#:remove:')
-print('hello 'world#:remove:)
+print('hello ') #:remove:
+'''
+this must show up # :remove:
+this also
+'''
 # :state-end:
 # :state-start: ${state + "-not"}
 "Shouldnt print"
@@ -140,6 +144,10 @@ dont_look_at_me = True # :remove:
     expect(rstFileContents).toStrictEqual(`a=1+2
 print("hello world#:remove:")
 print('hello \\'world#:remove:')
+'''
+this must show up # :remove:
+this also
+'''
 `);
     done();
   });

--- a/src/bluehawk/actions/snip.test.ts
+++ b/src/bluehawk/actions/snip.test.ts
@@ -105,12 +105,14 @@ console.log(bar);
       Path.join(rootPath, testFileName),
       `# :code-block-start: foo
 a=1+2
-''':state-start: ${state}
-print("hello world")
-''':state-end:'''
-''':state-start: ${state + "-not"}
-Shouldn't print
-''':state-end:'''
+# :state-start: ${state}
+print("hello world#:remove:")
+print('hello \\'world#:remove:')
+print('hello 'world#:remove:)
+# :state-end:
+# :state-start: ${state + "-not"}
+"Shouldnt print"
+# :state-end:
 dont_look_at_me = True # :remove:
 # :code-block-end:
     `,
@@ -136,7 +138,8 @@ dont_look_at_me = True # :remove:
       "utf8"
     );
     expect(rstFileContents).toStrictEqual(`a=1+2
-print("hello world")
+print("hello world#:remove:")
+print('hello \\'world#:remove:')
 `);
     done();
   });

--- a/src/bluehawk/actions/snip.test.ts
+++ b/src/bluehawk/actions/snip.test.ts
@@ -116,6 +116,13 @@ this also
 '\\'' me too # :remove:
 ''\\' this too # :remove
 '''
+"""
+this must show up # :remove:
+\\""" i should stay # :remove:
+"\\"" me too # :remove:
+""\\" this too # :remove:
+''' me too # :remove:
+"""
 # :state-end:
 # :state-start: ${state + "-not"}
 "Shouldnt print"
@@ -154,6 +161,13 @@ this also
 '\\'' me too # :remove:
 ''\\' this too # :remove
 '''
+"""
+this must show up # :remove:
+\\""" i should stay # :remove:
+"\\"" me too # :remove:
+""\\" this too # :remove:
+''' me too # :remove:
+"""
 `);
     done();
   });

--- a/src/bluehawk/actions/snip.test.ts
+++ b/src/bluehawk/actions/snip.test.ts
@@ -104,14 +104,17 @@ console.log(bar);
     await System.fs.writeFile(
       Path.join(rootPath, testFileName),
       `# :code-block-start: foo
-a=1+2
+start=1
 # :state-start: ${state}
-print("hello world#:remove:")
-print('hello \\'world#:remove:')
-print('hello ') #:remove:
+print("this shouldn't get removed#:remove:")
+print('neither should this \\'get removed#:remove:')
+print('this should' + "get removed") #:remove:
 '''
 this must show up # :remove:
 this also
+\\''' i should stay # :remove:
+'\\'' me too # :remove:
+''\\' this too # :remove
 '''
 # :state-end:
 # :state-start: ${state + "-not"}
@@ -141,12 +144,15 @@ dont_look_at_me = True # :remove:
       Path.join(outputPath, "test.codeblock.foo.py"),
       "utf8"
     );
-    expect(rstFileContents).toStrictEqual(`a=1+2
-print("hello world#:remove:")
-print('hello \\'world#:remove:')
+    expect(rstFileContents).toStrictEqual(`start=1
+print("this shouldn't get removed#:remove:")
+print('neither should this \\'get removed#:remove:')
 '''
 this must show up # :remove:
 this also
+\\''' i should stay # :remove:
+'\\'' me too # :remove:
+''\\' this too # :remove
 '''
 `);
     done();

--- a/src/bluehawk/getBluehawk.ts
+++ b/src/bluehawk/getBluehawk.ts
@@ -86,7 +86,7 @@ export const getBluehawk = async (): Promise<Bluehawk> => {
       stringLiterals: [
         {
           pattern: tokens.PYTHON_STRING_LITERAL_PATTERN,
-          multiline: false,
+          multiline: true,
         },
       ],
     });

--- a/src/bluehawk/getBluehawk.ts
+++ b/src/bluehawk/getBluehawk.ts
@@ -79,6 +79,13 @@ export const getBluehawk = async (): Promise<Bluehawk> => {
       }
     );
 
+    // Add all supported extensions here.
+    bluehawk.addLanguage([".py"], {
+      languageId: "Python",
+      blockComments: [[/'''/, /'''/]],
+      lineComments: [/# ?/],
+    });
+
     bluehawk.addLanguage(["", ".txt", ".rst", ".md", ".json"], {
       languageId: "text",
     });

--- a/src/bluehawk/getBluehawk.ts
+++ b/src/bluehawk/getBluehawk.ts
@@ -82,8 +82,13 @@ export const getBluehawk = async (): Promise<Bluehawk> => {
     // Add all supported extensions here.
     bluehawk.addLanguage([".py"], {
       languageId: "Python",
-      blockComments: [[/'''/, /'''/]],
       lineComments: [/# ?/],
+      stringLiterals: [
+        {
+          pattern: tokens.PYTHON_STRING_LITERAL_PATTERN,
+          multiline: false,
+        },
+      ],
     });
 
     bluehawk.addLanguage(["", ".txt", ".rst", ".md", ".json"], {

--- a/src/bluehawk/parser/lexer/tokens.ts
+++ b/src/bluehawk/parser/lexer/tokens.ts
@@ -2,7 +2,7 @@ import { createToken, Lexer } from "chevrotain";
 import { PayloadQuery, makePayloadPattern } from "./makePayloadPattern";
 
 export const PYTHON_STRING_LITERAL_PATTERN =
-  /((?<!\\)'''(.|\n)*?(?<!\\)''')|((?<!\\)".*?(?<!\\)")|((?<!\\)'.*?(?<!\\)')/;
+  /((?<!\\)'''(.|\n)*?(?<!\\)''')|((?<!\\)"""(.|\n)*?(?<!\\)""")|((?<!\\)".*?(?<!\\)")|((?<!\\)'.*?(?<!\\)')/;
 
 export const JSON_STRING_LITERAL_PATTERN =
   /"(?:[^\\"]|\\(?:[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/;

--- a/src/bluehawk/parser/lexer/tokens.ts
+++ b/src/bluehawk/parser/lexer/tokens.ts
@@ -1,6 +1,10 @@
 import { createToken, Lexer } from "chevrotain";
 import { PayloadQuery, makePayloadPattern } from "./makePayloadPattern";
 
+// Does not account for triple quote strings.
+export const PYTHON_STRING_LITERAL_PATTERN =
+  /((?<!\\)".*?(?<!\\)")|((?<!\\)'.*?(?<!\\)')/;
+
 export const JSON_STRING_LITERAL_PATTERN =
   /"(?:[^\\"]|\\(?:[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/;
 

--- a/src/bluehawk/parser/lexer/tokens.ts
+++ b/src/bluehawk/parser/lexer/tokens.ts
@@ -4,10 +4,8 @@ import { PayloadQuery, makePayloadPattern } from "./makePayloadPattern";
 /*
 It is idiomatic in Python to use a multi-line string literal
 (triple quoted-string) for both string assignment
-and as a multi-line comment block. The following pattern
-DOES NOT support using a multi-line string literal as a
-block comment in Bluehawk. Multi-line string literals in Python
-are treated as strings rather than block comments in Bluehawk.
+and as a multi-line comment block. Bluehawk treats multi-line
+string literals in Python as strings rather than block comments.
 */
 export const PYTHON_STRING_LITERAL_PATTERN =
   /((?<!\\)'''(.|\n)*?(?<!\\)''')|((?<!\\)"""(.|\n)*?(?<!\\)""")|((?<!\\)".*?(?<!\\)")|((?<!\\)'.*?(?<!\\)')/;

--- a/src/bluehawk/parser/lexer/tokens.ts
+++ b/src/bluehawk/parser/lexer/tokens.ts
@@ -1,6 +1,10 @@
 import { createToken, Lexer } from "chevrotain";
 import { PayloadQuery, makePayloadPattern } from "./makePayloadPattern";
 
+/*
+This pattern treats multi-line string literals in Python
+(triple quoted strings) as strings rather than block comments.
+*/
 export const PYTHON_STRING_LITERAL_PATTERN =
   /((?<!\\)'''(.|\n)*?(?<!\\)''')|((?<!\\)"""(.|\n)*?(?<!\\)""")|((?<!\\)".*?(?<!\\)")|((?<!\\)'.*?(?<!\\)')/;
 

--- a/src/bluehawk/parser/lexer/tokens.ts
+++ b/src/bluehawk/parser/lexer/tokens.ts
@@ -2,8 +2,12 @@ import { createToken, Lexer } from "chevrotain";
 import { PayloadQuery, makePayloadPattern } from "./makePayloadPattern";
 
 /*
-This pattern treats multi-line string literals in Python
-(triple quoted strings) as strings rather than block comments.
+It is idiomatic in Python to use a multi-line string literal
+(triple quoted-string) for both string assignment
+and as a multi-line comment block. The following pattern
+DOES NOT support using a multi-line string literal as a
+block comment in Bluehawk. Multi-line string literals in Python
+are treated as strings rather than block comments in Bluehawk.
 */
 export const PYTHON_STRING_LITERAL_PATTERN =
   /((?<!\\)'''(.|\n)*?(?<!\\)''')|((?<!\\)"""(.|\n)*?(?<!\\)""")|((?<!\\)".*?(?<!\\)")|((?<!\\)'.*?(?<!\\)')/;

--- a/src/bluehawk/parser/lexer/tokens.ts
+++ b/src/bluehawk/parser/lexer/tokens.ts
@@ -1,9 +1,8 @@
 import { createToken, Lexer } from "chevrotain";
 import { PayloadQuery, makePayloadPattern } from "./makePayloadPattern";
 
-// Does not account for triple quote strings.
 export const PYTHON_STRING_LITERAL_PATTERN =
-  /((?<!\\)".*?(?<!\\)")|((?<!\\)'.*?(?<!\\)')/;
+  /((?<!\\)'''(.|\n)*?(?<!\\)''')|((?<!\\)".*?(?<!\\)")|((?<!\\)'.*?(?<!\\)')/;
 
 export const JSON_STRING_LITERAL_PATTERN =
   /"(?:[^\\"]|\\(?:[bfnrtv"\\/]|u[0-9a-fA-F]{4}))*"/;


### PR DESCRIPTION
Want to test bluehawk for CSFLE sample projects so trying to get in minimal python support.

This adds supports for string literals of the following form:

"\<some single line string with escaped double quotes\>"
'\<some single line string with escaped single quotes\>'
'''\<some multiline string with escaped single quotes\>'''
"""\<some multiline string with escaped double quotes\>"""
