### PR TITLE
Markdown formatted output

### DIFF
--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -70,7 +70,9 @@ state, and no other states, in the generated output.
 
 Pass the name of a markup syntax to the `--format` flag when generating snippets
 to generate a formatted version of that snippet in the specified markup syntax.
-This command currently supports
-[reStructuredText](https://en.wikipedia.org/wiki/ReStructuredText) syntax using
-`rst` and [docusaurus](https://docusaurus.io/docs/markdown-features/snippets#highlighting-with-comments)
-syntax with `docusaurus`.
+This command currently supports the following options:
+
+- `rst`: [ReStructuredText](https://en.wikipedia.org/wiki/ReStructuredText) syntax
+- `md`: [Markdown fenced codeblock](https://www.markdownguide.org/extended-syntax/#fenced-code-blocks) syntax
+  using backticks (`). Markdown format does not support the [emphasize tag](./tags#emphasize).
+- `docusaurus`: Docusaurus syntax with [comment highlighting](https://docusaurus.io/docs/markdown-features/code-blocks#highlighting-with-comments)

--- a/docs/docs/reference/tags.md
+++ b/docs/docs/reference/tags.md
@@ -377,8 +377,14 @@ line numbers for you.
 
 You can use `emphasize` as either a block tag or a line tag.
 
-> 💡 The emphasize tag only applies to [formatted output](./cli#format).
-> Use the `--format` flag with Bluehawk CLI to get formatted output.
+:::note
+
+The emphasize tag only applies to certain formatted outputs.
+Use the `--format` flag with Bluehawk CLI to get formatted output.
+For more information on support for `emphasize`,
+refer to the [formatted output documentation](./cli#format).
+
+:::
 
 Consider the following file:
 

--- a/src/bluehawk/actions/snip.test.ts
+++ b/src/bluehawk/actions/snip.test.ts
@@ -89,6 +89,70 @@ console.log(bar);
     done();
   });
 
+  it("generates correct MD fenced snippets", async (done) => {
+    const rootPath = Path.resolve("/path/to/project");
+    const outputPath = "/output";
+    const testFileName = "test.js";
+
+    await System.fs.mkdir(rootPath, {
+      recursive: true,
+    });
+    await System.fs.mkdir(outputPath, {
+      recursive: true,
+    });
+    await System.fs.writeFile(
+      Path.join(rootPath, testFileName),
+      `        // :snippet-start: foo
+        const bar = "foo"
+        // :emphasize-start:
+        describe("some stuff", () => {
+          it("foos the bar", () => {
+            expect(true).toBeTruthy();
+          });
+        });
+        // :emphasize-end:
+        console.log(bar);
+        // :snippet-end:
+    `,
+      {
+        encoding: "utf8",
+      }
+    );
+
+    await snip({
+      reporter,
+      paths: [rootPath],
+      output: outputPath,
+      state: undefined,
+      ignore: undefined,
+      format: ["md"],
+      waitForListeners: true,
+    });
+
+    const outputList = await System.fs.readdir(outputPath);
+    expect(outputList).toStrictEqual([
+      "test.snippet.foo.js",
+      "test.snippet.foo.js.md",
+    ]);
+    const mdFileContents = await System.fs.readFile(
+      Path.join(outputPath, "test.snippet.foo.js.md"),
+      "utf8"
+    );
+    expect(mdFileContents).toStrictEqual(`\`\`\`js
+
+const bar = "foo"
+describe("some stuff", () => {
+  it("foos the bar", () => {
+    expect(true).toBeTruthy();
+  });
+});
+console.log(bar);
+
+\`\`\``);
+
+    done();
+  });
+
   it("generates correct Python snippets", async (done) => {
     const rootPath = Path.resolve("/path/to/project");
     const outputPath = "/output";

--- a/src/bluehawk/actions/snip.ts
+++ b/src/bluehawk/actions/snip.ts
@@ -139,8 +139,8 @@ export const formatInMd = (result: ProcessResult): string | undefined => {
     return undefined;
   }
   const language = document.extension.slice(1);
-  const startBackticks = `\`\`\`${language}\n\n`;
-  const endBackticks = `\n\`\`\``;
+  const startBackticks = ["```", language, "\n\n"].join("");
+  const endBackticks = "\n```";
 
   return startBackticks + document.text.toString() + endBackticks;
 };

--- a/src/bluehawk/actions/snip.ts
+++ b/src/bluehawk/actions/snip.ts
@@ -6,7 +6,7 @@ import { ActionArgs } from "./ActionArgs";
 import { ProcessResult } from "../../bluehawk/processor/Processor";
 import { logErrorsToConsole } from "../../bluehawk/OnErrorFunction";
 
-type Format = "rst" | "docusaurus";
+type Format = "rst" | "docusaurus" | "md";
 
 export interface SnipArgs extends ActionArgs {
   paths: string[];
@@ -35,6 +35,16 @@ export const createFormattedCodeBlock = async ({
     const targetPath = path.join(output, `${document.basename}.rst`);
     await System.fs.writeFile(targetPath, formattedSnippet, "utf8");
 
+    reporter.onFileWritten({
+      type: "text",
+      inputPath: document.path,
+      outputPath: targetPath,
+    });
+  } else if (format === "md") {
+    const formattedSnippet = formatInMd(result);
+    const { document } = result;
+    const targetPath = path.join(output, `${document.basename}.md`);
+    await System.fs.writeFile(targetPath, formattedSnippet, "utf8");
     reporter.onFileWritten({
       type: "text",
       inputPath: document.path,
@@ -122,6 +132,19 @@ export const formatInRst = async (
   return formattedSnippet;
 };
 
+export const formatInMd = (result: ProcessResult): string | undefined => {
+  const { document } = result;
+  const snippet = document.attributes["snippet"];
+  if (snippet === undefined) {
+    return undefined;
+  }
+  const language = document.extension.slice(1);
+  const startBackticks = `\`\`\`${language}\n\n`;
+  const endBackticks = `\n\`\`\``;
+
+  return startBackticks + document.text.toString() + endBackticks;
+};
+
 export const formatInDocusaurus = async (
   result: ProcessResult
 ): Promise<string | undefined> => {
@@ -160,7 +183,6 @@ export const formatInDocusaurus = async (
   // pop some newlines in between those lines so it doesn't come out as one long single-line spew of insanity
   return lines.join("\n");
 };
-
 export const snip = async (
   args: WithActionReporter<SnipArgs>
 ): Promise<void> => {


### PR DESCRIPTION
new `md` output for `--format`.

output is formatted in a markdown codeblock, such as 

````md
```js
const foo = 'bar';
```
````

note: doesn't support line highlighting

addresses https://github.com/mongodb-university/Bluehawk/issues/112 