### PR TITLE
remove "uncomment" from state-end

### DIFF
--- a/docs/docs/use-cases.md
+++ b/docs/docs/use-cases.md
@@ -79,7 +79,7 @@ indicate different states or checkpoints with the `:state-start:` and
     // :state-start: start
     // TODO: Use the app's emailPasswordAuth to registerUser with the email and password.
     // When registered, call signIn().
-    // :state-uncomment-end:
+    // :state-end:
 }
 // :snippet-end:
 // ... more code ...


### PR DESCRIPTION
A code sample on [this page](https://mongodb-university.github.io/Bluehawk/use-cases) uses :state-uncomment-end: when it appears :state-end: should be used.