### PR TITLE
fixed bug that was creating both formatted file type (.rst|.md|etc) and regular files (.js|.swift|etc)

### DIFF
--- a/src/bluehawk/actions/snip.test.ts
+++ b/src/bluehawk/actions/snip.test.ts
@@ -51,7 +51,6 @@ describe("snip", () => {
 
     const outputList = await System.fs.readdir(outputPath);
     expect(outputList).toStrictEqual([
-      "test.snippet.foo.js",
       "test.snippet.foo.js.md",
       "test.snippet.foo.js.rst",
     ]);
@@ -129,10 +128,7 @@ console.log(bar);
     });
 
     const outputList = await System.fs.readdir(outputPath);
-    expect(outputList).toStrictEqual([
-      "test.snippet.foo.js",
-      "test.snippet.foo.js.md",
-    ]);
+    expect(outputList).toStrictEqual(["test.snippet.foo.js.md"]);
     const mdFileContents = await System.fs.readFile(
       Path.join(outputPath, "test.snippet.foo.js.md"),
       "utf8"
@@ -273,10 +269,7 @@ console.log(bar);
     });
 
     const outputList = await System.fs.readdir(outputPath);
-    expect(outputList).toStrictEqual([
-      "test.snippet.foo.js",
-      "test.snippet.foo.js.md",
-    ]);
+    expect(outputList).toStrictEqual(["test.snippet.foo.js.md"]);
 
     const fileContents = await System.fs.readFile(
       Path.join(outputPath, "test.snippet.foo.js.md"),
@@ -338,10 +331,7 @@ line 9
       waitForListeners: true,
     });
     const outputList = await System.fs.readdir(outputPath);
-    expect(outputList).toStrictEqual([
-      "test.snippet.foo.js",
-      "test.snippet.foo.js.rst",
-    ]);
+    expect(outputList).toStrictEqual(["test.snippet.foo.js.rst"]);
 
     const fileContents = await System.fs.readFile(
       Path.join(outputPath, "test.snippet.foo.js.rst"),
@@ -407,10 +397,7 @@ line 9
     });
 
     const outputList = await System.fs.readdir(outputPath);
-    expect(outputList).toStrictEqual([
-      "test.snippet.foo.js",
-      "test.snippet.foo.js.md",
-    ]);
+    expect(outputList).toStrictEqual(["test.snippet.foo.js.md"]);
 
     const fileContents = await System.fs.readFile(
       Path.join(outputPath, "test.snippet.foo.js.md"),
@@ -544,6 +531,22 @@ struct ContentView: SwiftUI.App {
       paths: [rootPath],
       output: outputPathLocal,
       format: "rst",
+      state: "local",
+    });
+
+    // non-rst snip for sync
+    await snip({
+      reporter,
+      paths: [rootPath],
+      output: outputPathSync,
+      state: "sync",
+    });
+
+    // non-rst snip for local
+    await snip({
+      reporter,
+      paths: [rootPath],
+      output: outputPathLocal,
       state: "local",
     });
 

--- a/src/bluehawk/actions/snip.ts
+++ b/src/bluehawk/actions/snip.ts
@@ -33,7 +33,6 @@ export const createFormattedCodeBlock = async ({
     if (formattedSnippet === undefined) {
       return;
     }
-
     const { document } = result;
     const targetPath = path.join(output, `${document.basename}.rst`);
     await System.fs.writeFile(targetPath, formattedSnippet, "utf8");
@@ -236,7 +235,7 @@ export const snip = async (
       stateVersionWrittenForPath[document.path] = true;
     }
 
-    if (id !== undefined) {
+    if (id) {
       const idAttribute: string = document.attributes["snippet"];
 
       if (![id].flat(1).includes(idAttribute)) {
@@ -248,15 +247,8 @@ export const snip = async (
     }
 
     try {
-      await System.fs.writeFile(targetPath, document.text.toString(), "utf8");
-      reporter.onFileWritten({
-        type: "text",
-        inputPath: document.path,
-        outputPath: targetPath,
-      });
-
       // Create formatted snippet block
-      if (formats !== undefined) {
+      if (formats) {
         for (const format of formats) {
           await createFormattedCodeBlock({
             result,
@@ -265,6 +257,14 @@ export const snip = async (
             reporter,
           });
         }
+      } else {
+        // only perform a write if we haven't already created the file in rST|md|etc
+        await System.fs.writeFile(targetPath, document.text.toString(), "utf8");
+        reporter.onFileWritten({
+          type: "text",
+          inputPath: document.path,
+          outputPath: targetPath,
+        });
       }
     } catch (error) {
       reporter.onWriteFailed({


### PR DESCRIPTION
### Bug fix explanation:
This PR fixes a bug that creates both formatted files and non-formatted files when running the  snip command with a format specified.

For example, in Bluehawk 1.3.1 if we run the following command: 
`bluehawk snip __tests__/ts/CRUD/delete-test.tsx -o outputfolder --format=rst` 

this will produce 2 files:
```
├── delete-test.snippet.crud-delete-object.tsx
└── delete-test.snippet.crud-delete-object.tsx.rst
```
Whereas it should only produce:

```
└── delete-test.snippet.crud-delete-object.tsx.rst
```
since the format specified is "rst" (i.e it should not produce the 'tsx' file.

This PR fixes that. 

### Passing Tests:
![Screen Shot 2022-12-16 at 6 06 35 PM](https://user-images.githubusercontent.com/52428905/208203081-6a4ecd4b-0ff8-4def-bf26-dfa7d9a0503e.png)

