### PR TITLE
Add .jsx and .tsx to rstLanguageMap

### DIFF
--- a/src/bluehawk/actions/snip.ts
+++ b/src/bluehawk/actions/snip.ts
@@ -92,11 +92,13 @@ export const formatInRst = async (
     [".gradle", "groovy"],
     [".java", "java"],
     [".js", "javascript"],
+    [".jsx", "javascript"],
     [".json", "json"],
     [".kt", "kotlin"],
     [".m", "objectivec"],
     [".swift", "swift"],
     [".ts", "typescript"],
+    [".tsx", "typescript"],
   ]);
   const rstLanguage = rstLanguageMap.has(document.extension)
     ? rstLanguageMap.get(document.extension)


### PR DESCRIPTION
Extending the nasty `rstLanguageMap` hack so that I create `.rst`-formatted samples for React Native.

Looks like a test failed - but I didn't touch that. Something to look into later?

```
Test failed: ./logLevel
Compare ./logLevel/expected and ./logLevel/output to debug.
```