### PR TITLE
Fix C++ syntax collision

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [21.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/integrationTests/snip/expected/sample.snippet.cpp-test.cpp
+++ b/integrationTests/snip/expected/sample.snippet.cpp-test.cpp
@@ -1,0 +1,1 @@
+auto something = SomeClass::someProperty;

--- a/integrationTests/snip/expected/sample.snippet.failing-cpp-test.cpp
+++ b/integrationTests/snip/expected/sample.snippet.failing-cpp-test.cpp
@@ -1,0 +1,1 @@
+auto something = SomeClass::state::something;

--- a/integrationTests/snip/input/sample.cpp
+++ b/integrationTests/snip/input/sample.cpp
@@ -1,0 +1,7 @@
+// :snippet-start: cpp-test
+auto something = SomeClass::someProperty;
+// :snippet-end:
+
+// :snippet-start: failing-cpp-test
+auto something = SomeClass::state::something;
+// :snippet-end:

--- a/src/bluehawk/parser/lexer/lexer.test.ts
+++ b/src/bluehawk/parser/lexer/lexer.test.ts
@@ -65,6 +65,34 @@ this is used to replace
       "Newline",
     ]);
   });
+
+  it("does not misinterpret C++ syntax as tokens", () => {
+    const result = lexer.tokenize(`SomeClass::state::something;`);
+    expect(result.errors.length).toBe(0);
+    const tokenNames = result.tokens.map((token) => token.tokenType.name);
+    expect(tokenNames).toBeNull;
+  });
+
+  it("Correctly tokenizes C++ syntax within a tag", () => {
+    const result = lexer.tokenize(`
+// :state-start: state-identifier
+SomeClass::state::something;
+// :state-end:
+`);
+    expect(result.errors.length).toBe(0);
+    const tokenNames = result.tokens.map((token) => token.tokenType.name);
+    expect(tokenNames).toStrictEqual([
+      "Newline",
+      "LineComment",
+      "TagStart",
+      "Identifier",
+      "Newline",
+      "Newline",
+      "LineComment",
+      "TagEnd",
+      "Newline",
+    ]);
+  });
 });
 
 describe("custom comment lexer", () => {
@@ -116,9 +144,13 @@ describe("custom comment lexer", () => {
 
   it("rejects comment patterns that conflict with other tokens", () => {
     expect(() => {
-      makeLexer([makeLineCommentToken(TAG_PATTERN)]);
-    }).toThrowError(`Errors detected in definition of Lexer:
-The same RegExp pattern ->/:([A-z0-9-]+):[^\\S\\r\\n]*/<-has been used in all of the following Token Types: Tag, LineComment <-`);
+      try {
+        makeLexer([makeLineCommentToken(TAG_PATTERN)]);
+      } catch (e) {
+        expect(e.message).toBe(`Errors detected in definition of Lexer:
+        The same RegExp pattern ->/(?<!:):([A-z0-9-]+):(?!:)[^\\S\\r\\n]*/<-has been used in all of the following Token Types: Tag, LineComment <-`);
+      }
+    });
   });
 });
 

--- a/src/bluehawk/parser/lexer/lexer.test.ts
+++ b/src/bluehawk/parser/lexer/lexer.test.ts
@@ -73,6 +73,49 @@ this is used to replace
     expect(tokenNames).toBeNull;
   });
 
+  it("does not make a token from content that starts with ::", () => {
+    const result = lexer.tokenize(`::SomeClass::state::something;`);
+    expect(result.errors.length).toBe(0);
+    const tokenNames = result.tokens.map((token) => token.tokenType.name);
+    expect(tokenNames).toBeNull;
+  });
+
+  it("does not make a token from content that ends with ::", () => {
+    const result = lexer.tokenize(`SomeClass::state::something::`);
+    expect(result.errors.length).toBe(0);
+    const tokenNames = result.tokens.map((token) => token.tokenType.name);
+    expect(tokenNames).toBeNull;
+  });
+
+  it("does not make a token from content that starts and ends with ::", () => {
+    const result = lexer.tokenize(`::SomeClass::state::something::`);
+    expect(result.errors.length).toBe(0);
+    const tokenNames = result.tokens.map((token) => token.tokenType.name);
+    expect(tokenNames).toBeNull;
+  });
+
+  it("does not make a token with a space in the state tag", () => {
+    const result = lexer.tokenize(`
+// :state -start: state-identifier
+SomeClass::state::something;
+// :state-end:
+    `);
+    expect(result.errors.length).toBe(0);
+    const tokenNames = result.tokens.map((token) => token.tokenType.name);
+    expect(tokenNames).toBeNull;
+  });
+
+  it("does not make a token with a space after the start colon", () => {
+    const result = lexer.tokenize(`
+// : state-start: state-identifier
+SomeClass::state::something;
+// :state-end:
+    `);
+    expect(result.errors.length).toBe(0);
+    const tokenNames = result.tokens.map((token) => token.tokenType.name);
+    expect(tokenNames).toBeNull;
+  });
+
   it("Correctly tokenizes C++ syntax within a tag", () => {
     const result = lexer.tokenize(`
 // :state-start: state-identifier

--- a/src/bluehawk/parser/lexer/tokens.ts
+++ b/src/bluehawk/parser/lexer/tokens.ts
@@ -82,24 +82,30 @@ const Text = createToken({
 // TODO: Allow any amount of non-newline white space (/[^\S\r\n]*/) to be
 // included before or after the actual tag name to make stripping it out
 // much easier.
-const TAG_START_PATTERN /**/ = /:([A-z0-9-]+)-start:/;
-const TAG_END_PATTERN /*  */ = /:([A-z0-9-]+)-end:/;
-const TAG_PATTERN /*      */ = /:([A-z0-9-]+):[^\S\r\n]*/;
+const TAG_START_PATTERN /**/ = /(?<!:):([A-z0-9-]+)-start:(?!:)/;
+const TAG_END_PATTERN /*  */ = /(?<!:):([A-z0-9-]+)-end:(?!:)/;
+const TAG_PATTERN /*      */ = /(?<!:):([A-z0-9-]+):(?!:)[^\S\r\n]*/;
 
 const TagStart = createToken({
   name: "TagStart",
   pattern: TAG_START_PATTERN,
   push_mode: "TagAttributesMode",
+  line_breaks: false,
+  start_chars_hint: [":"],
 });
 
 const TagEnd = createToken({
   name: "TagEnd",
   pattern: TAG_END_PATTERN,
+  line_breaks: false,
+  start_chars_hint: [":"],
 });
 
 const Tag = createToken({
   name: "Tag",
   pattern: TAG_PATTERN,
+  line_breaks: false,
+  start_chars_hint: [":"],
 });
 
 const Identifier = createToken({

--- a/src/bluehawk/parser/visitor/jsonAttributeList.test.ts
+++ b/src/bluehawk/parser/visitor/jsonAttributeList.test.ts
@@ -84,12 +84,12 @@ describe("JSON attribute lists", () => {
     const result = visitor.visit(cst, source);
     expect(result.tagNodes[0].attributes).toBeUndefined();
     expect(result.errors[0].message).toBe(
-      "Expected double-quoted property name in JSON"
+      "Expected double-quoted property name in JSON at position 19 (line 5 column 3)"
     );
     expect(result.errors[0].location).toStrictEqual({
-      line: 5,
-      column: 3,
-      offset: 33,
+      line: 1,
+      column: 15,
+      offset: 14,
     });
   });
 
@@ -133,12 +133,12 @@ describe("JSON attribute lists", () => {
     const visitor = makeCstVisitor(parser);
     const result = visitor.visit(cst, source);
     expect(result.errors[0].location).toStrictEqual({
-      line: 5,
-      column: 1,
-      offset: 23,
+      line: 1,
+      column: 15,
+      offset: 14,
     });
     expect(result.errors[0].message).toBe(
-      "Expected property name or '}' in JSON"
+      "Expected property name or '}' in JSON at position 9 (line 5 column 1)"
     );
   });
 
@@ -158,12 +158,12 @@ describe("JSON attribute lists", () => {
     const visitor = makeCstVisitor(parser);
     const result = visitor.visit(cst, source);
     expect(result.errors[0].location).toStrictEqual({
-      line: 5,
-      column: 1,
-      offset: 21,
+      line: 1,
+      column: 15,
+      offset: 14,
     });
     expect(result.errors[0].message).toBe(
-      "Expected property name or '}' in JSON"
+      "Expected property name or '}' in JSON at position 7 (line 5 column 1)"
     );
   });
 
@@ -250,12 +250,12 @@ describe("JSON attribute lists", () => {
     const visitor = makeCstVisitor(parser);
     const result = visitor.visit(cst, source);
     expect(result.errors[0].location).toStrictEqual({
-      line: 3,
-      column: 4,
-      offset: 39,
+      line: 1,
+      column: 18,
+      offset: 17,
     });
     expect(result.errors[0].message).toBe(
-      "Expected double-quoted property name in JSON"
+      "Expected double-quoted property name in JSON at position 22 (line 3 column 4)"
     );
   });
 });


### PR DESCRIPTION
Closes #145 

This adds regex to avoid matching Bluehawk tags surrounded by `::` - it should only match tags with a single `:` surrounding them. This resolves C++ syntax issues, as C++ uses `::` to reference class members.

Added a test - with the old patterns, it fails as expected, but with the new patterns, the integration test runs.

This also coincidentally fixes 1 of the failing tests reported in #149.

Upon initially adding the new regex, I got a few warnings from Chevrotain which Bluehawk reported as Errors. First was `Unable to identify line terminator usage in pattern`, detailed in the Chevrotain docs here: https://chevrotain.io/docs/guide/resolving_lexer_errors.html#IDENTIFY_TERMINATOR

Adding `line_breaks: false,` resolved this warning/error.

Then I got `Failed parsing < /.../ > Using the regexp-to-ast library`, detailed in the Chevrotain docs here: https://chevrotain.io/docs/guide/resolving_lexer_errors.html#REGEXP_PARSING

Per the docs recommendation, I added the `start_chars_hint` property to resolve these errors.

With these changes, the only failing tests are now tests that were failing before this PR.